### PR TITLE
Add Multi-MCP project

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [lightconetech/mcp-gateway](https://github.com/lightconetech/mcp-gateway) 📇 - A gateway demo for MCP SSE Server
 - [EvalsOne/MCP-Connect](https://github.com/EvalsOne/MCP-Connect) 📇 - A tiny tool that enables cloud-based AI services to access local Stdio based MCP servers via HTTP/HTTPS
 - [SecretiveShell/MCP-Bridge](https://github.com/SecretiveShell/MCP-Bridge) 🐍 – An openAI middleware proxy to use MCP in any existing openAI compatible client
+- [multi-mcp](https://github.com/kfirtoledo/multi-mcp) 🐍 - A flexible and dynamic Multi-MCP Proxy Server that acts as a single MCP server while connecting to and routing between multiple backend MCP servers over STDIO or SSE. Deployable on Kubernetes by exposing a single port, and supports dynamic addition and removal of MCP servers at runtime.
 
 ### Development Tools
 


### PR DESCRIPTION
Adding the Multi-MCP project- a flexible and dynamic Multi-MCP Proxy Server that acts as a single MCP server while connecting to and routing between multiple backend MCP servers over STDIO or SSE.

🚀 Features
✅ Supports both STDIO and SSE transports
✅ Can connect to MCP servers running in either STDIO or SSE mode
✅ Proxies requests to multiple MCP servers
✅ Automatically initializes capabilities (tools, prompts, resources) from connected servers
✅ Dynamically add/remove MCP servers at runtime (via HTTP API)
✅ Supports tools with the same name on different servers (using namespacing)
✅ Deployable on Kubernetes, exposing a single port to access all connected MCP servers through the proxy

Link to our [blog](https://itnext.io/multi-mcp-exposing-multiple-mcp-servers-as-one-5732ebe3ba20).