### PR TITLE
Add ToolHive to Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [strowk/mcp-autotest](https://github.com/strowk/mcp-autotest) 🏎️ - A command-line tool for running YAML based language-agnostic autotests
 - [strowk/synf](https://github.com/strowk/synf) 🦀 - Tool to hot-reload MCP server on changes to saved files
 - [strowk/mcptee](https://github.com/strowk/mcptee/) 🏎️ - Tool to proxy MCP and log inputs and outputs to YAML file
+- [StacklokLabs/toolhive](https://github.com/StacklokLabs/toolhive) 🏎️ - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization
 
 
 ## Hosting


### PR DESCRIPTION
ToolHive is a lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security. It provides a curated registry of MCPs with verified configurations, secure secrets management, and standardized packaging using OCI containers.