### PR TITLE
add dart-mcp-server-template and new templates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A curated list of developer tools, SDKs, libraries, utilities, and resources for
   * 📇 – TypeScript codebase
   * 🔶 - Kotlin codebase
   * 🦀 – Rust codebase
+  * 🎯 - Dart codebase
 
 ## SDKs
 
@@ -143,6 +144,13 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 > Libraries & platforms for hosting MCP servers.
 
 - [Glama](https://glama.ai/mcp/servers) – offers hosting of open-source MCP servers, enabling developers and enterprises to easily discover build, manage MCP servers.
+
+## Templates
+
+> Example code ready to be made into a component of an MCP system.
+
+- [dart-mcp-server-template](https://github.com/jhgaylor/dart-mcp-server-template) 🎯 - A template repository for creating Dart MCP servers. Provides a starting point with Docker configuration, http+stdio transport bindings, and a standard Dart project structure
+
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A curated list of developer tools, SDKs, libraries, utilities, and resources for
 - [Build Tools](#build-tools)
 - [Utilities](#utilities)
 - [Hosting](#hosting)
+- [Templates](#templates)
 - [Resources](#resources)
 - [Tutorials](#tutorials)
 


### PR DESCRIPTION
This is a dart template repo that can be cloned and now the developer has a new project ready to start. 