### PR TITLE
add f/mcp-startup-boilerplate as Rails Template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 > Example code ready to be made into a component of an MCP system.
 
 - [dart-mcp-server-template](https://github.com/jhgaylor/dart-mcp-server-template) 🎯 - A template repository for creating Dart MCP servers. Provides a starting point with Docker configuration, http+stdio transport bindings, and a standard Dart project structure
+- [rails-mcp-startup-boilerplate](https://github.com/f/mcp-startup-boilerplate) 💎 - A Rails template for creating Paid MCP servers compatible with Claude Integrations. It uses Rails 8.0.2, Devise, Doorkeeper, FastMCP and Stripe. Has a built-in UI.
 
 
 ## Resources


### PR DESCRIPTION
It's a new template that allows users to create Rails MCP servers that compatible with Claude Integrations.


https://github.com/user-attachments/assets/16d02ed1-2d8f-4fd3-a294-d69d6eafaa78

