### PR TITLE
docs: Add mcpport suport

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Public test endpoints:
 - [boilingdata/mcp-server-and-gw](https://github.com/boilingdata/mcp-server-and-gw) 📇 - An MCP stdio to HTTP SSE transport gateway
 - [emicklei/mcp-log-proxy](https://github.com/emicklei/mcp-log-proxy) 🏎️ - An MCP proxy server that offers a Web UI to see the complete message flow.
 - [EvalsOne/MCP-Connect](https://github.com/EvalsOne/MCP-Connect) 📇 - A tiny tool that enables cloud-based AI services to access local Stdio based MCP servers via HTTP/HTTPS
+- [fangyinc/mcpport](https://github.com/fangyinc/mcpport) 🐍 - A lightweight gateway & registry for MCP servers with NAT traversal support, allowing edge devices to provide MCP services across networks. Features include WebSocket/SSE/HTTP endpoints, authentication, IPv6 support, and a CLI tool for easy registration of stdio-based MCP servers.
 - [hamidra/yamcp](https://github.com/hamidra/yamcp) 📇 - An MCP workspace manager to bundle and manage MCP servers in dedicated local workspaces (e.g., for coding, design, research).
 - [lightconetech/mcp-gateway](https://github.com/lightconetech/mcp-gateway) 📇 - A gateway demo for MCP SSE Server
 - [multi-mcp](https://github.com/kfirtoledo/multi-mcp) 🐍 - A flexible and dynamic Multi-MCP Proxy Server that acts as a single MCP server while connecting to and routing between multiple backend MCP servers over STDIO or SSE. Deployable on Kubernetes by exposing a single port, and supports dynamic addition and removal of MCP servers at runtime.


### PR DESCRIPTION
## Description

[fangyinc/mcpport](https://github.com/fangyinc/mcpport): A lightweight MCP gateway & registry with NAT traversal support

This PR adds mcpport to the Utilities section. mcpport is a lightweight gateway and registry solution for Model Context Protocol (MCP) servers with NAT traversal capabilities, enabling edge devices to provide MCP services across networks.

## Key Features
- NAT traversal support for cross-network MCP tool access
- Multiple endpoint support (WebSocket, SSE, HTTP)
- Authentication mechanisms with Bearer token
- SSL/TLS support (with optional custom CA certificates)
- IPv6 support
- CLI tool for easy registration of stdio-based MCP servers

## Basic Usage
```bash
# Start the gateway
uvx mcpport gateway

# Register an MCP server
uvx mcpport register \
  --stdio "npx -y @modelcontextprotocol/server-filesystem ./" \
  --gateway-url "ws://localhost:8765/mcp/register" \
  --server-name "file"
```

The project is located at https://github.com/fangyinc/mcpport and aims to enhance the MCP ecosystem by enabling standardized connectivity for AI applications.