### PR TITLE
New Dev Tool: MCPJam Inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 ## Testing Tools 
 > Tools for testing MCP servers and clients 
 
+- [mcpjam/inspector](https://github.com/MCPJam/inspector) - Testing and debugging MCP servers.
 - [modelcontextprotocol/inspector](https://github.com/modelcontextprotocol/inspector) 📇 🎖️ - UI for testing MCP servers.
 - [wong2/mcp-cli](https://github.com/wong2/mcp-cli) 🤖 - Command line inspector for manual testing
 - [mclenhard/mcp-evals](https://github.com/mclenhard/mcp-evals) 🤖 - Package and Github action for running evals. 


### PR DESCRIPTION
I am the maintainer of the MCPJam inspector. It is an open source MCP server inspector, an alternative to the official inspector. 

Here's an [article](https://mcpjam.substack.com/p/debugging-mcp-servers-with-mcpjam) about the project.  