### PR TITLE
Add MCP Tool Factory to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [mcp-cli](https://github.com/tileshq/mcp-cli) 🐍 - A lightweight CLI MCP client to connect with remote MCP servers.
 - [MCPcat](https://github.com/mcpcat/mcpcat-python-sdk) 🐍 - User analytics, session tracking, and live debugging for MCPs
 - [basementstudio/xmcp](http://github.com/raw-labs/mxcp) 🐍 - Open-source framework for building secure, testable, enterprise-grade MCP tools from SQL or Python on top of dbt + DuckDB.
+- [MCP Tool Factory](https://github.com/heshamfs/mcp-tool-factory) 🐍 - Generate MCP servers from descriptions, OpenAPI specs, or databases using LLM. Multi-provider support.
 
 ### Java
 


### PR DESCRIPTION
Added MCP Tool Factory to the "For servers" section - an AI-powered Python framework that generates production-ready MCP servers from natural language descriptions, OpenAPI specifications, or database schemas.

Server Details

Server: MCP Tool Factory (Python)
Category: Server Framework / Code Generator
Repository: https://github.com/HeshamFS/mcp-tool-factory
Motivation and Context

MCP Tool Factory fills a gap in the ecosystem by providing an AI-powered way to generate complete MCP server packages:

Natural Language → MCP Server: Describe tools in plain English, get working code
OpenAPI → MCP Server: Auto-convert REST APIs with full auth support (API Key, Bearer, OAuth2)
Database → MCP Server: Generate CRUD tools from SQLite/PostgreSQL schemas
Multi-Provider: Works with Anthropic Claude, OpenAI GPT, and Google Gemini
Generated servers work with all MCP-compatible frameworks: Claude Code, OpenAI Agents SDK, Google ADK, LangChain, CrewAI, and more.

How Has This Been Tested?

✅ Tested with Claude Code and Claude Desktop
✅ 868 tests with 85%+ code coverage
✅ CI/CD pipeline with GitHub Actions
✅ Generated servers validated with multiple LLM clients