### PR TITLE
Add mcp-expertise-toolkit to Templates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Public test endpoints:
 - [fastmcp-boilerplate](https://github.com/punkpeye/fastmcp-boilerplate) 📇 – A simple MCP server built using FastMCP, TypeScript, ESLint, and Prettier.
 - [dart-mcp-server-template](https://github.com/jhgaylor/dart-mcp-server-template) 🎯 - A template repository for creating Dart MCP servers. Provides a starting point with Docker configuration, http+stdio transport bindings, and a standard Dart project structure
 - [rails-mcp-startup-boilerplate](https://github.com/f/mcp-startup-boilerplate) 💎 - A Rails template for creating Paid MCP servers compatible with Claude Integrations. It uses Rails 8.0.2, Devise, Doorkeeper, FastMCP and Stripe. Has a built-in UI.
+- [mcp-expertise-toolkit](https://github.com/lennyzeltser/mcp-expertise-toolkit) 📇 – Template for building expertise-based MCP servers on Cloudflare Workers. Define domain knowledge in YAML, deploy as AI-accessible guidance.
 
 
 ## Resources


### PR DESCRIPTION
Adds a template for building expertise-based MCP servers on Cloudflare Workers.

Unlike code-focused templates, this one focuses on domain expertise delivery - define knowledge in YAML, deploy as AI-accessible guidance. Includes validation tooling and sample domains (README review, BBQ scoring).

**Repo:** https://github.com/lennyzeltser/mcp-expertise-toolkit

**Production example:** https://website-mcp.zeltser.com/mcp (IR report writing guidance, listed on official MCP registry)