### PR TITLE
Add lc2mcp - LangChain to FastMCP tool converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [FastMCP](https://github.com/jlowin/fastmcp) 🐍 - A high-level framework for building MCP servers in Python
 - [mcp-use](https://github.com/mcp-use/mcp-use) 🐍 - Open source python library to very easily connect any LLM to any MCP server both locally and remotely.
 - [langchain-mcp](https://github.com/rectalogic/langchain-mcp) 🐍 - Provides MCP tool calling support in LangChain
+- [lc2mcp](https://github.com/xiaotonng/lc2mcp) 🐍 - Convert LangChain tools to FastMCP tools with one line of code, supports context injection and 1000+ langchain-community tools
 - [tadata-org/fastapi_mcp](https://github.com/tadata-org/fastapi_mcp) 🐍 - Provides MCP wrapping on top of existing FastAPI REST endpoints
 - [easymcp](https://github.com/promptmesh/easymcp) 🐍 - A high level asyncio native client SDK with native support for namespaced servers and caching.
 - [mcp-cli](https://github.com/tileshq/mcp-cli) 🐍 - A lightweight CLI MCP client to connect with remote MCP servers.


### PR DESCRIPTION
## Description

Adding [lc2mcp](https://github.com/xiaotonng/lc2mcp) to the Python SDKs section.

**lc2mcp** is a Python library that converts LangChain tools to FastMCP tools with one line of code.

## Features

- 🔄 Instant conversion of any LangChain tool to FastMCP tool
- 📦 Works with 1000+ langchain-community tools (DuckDuckGo, Wikipedia, SQL, etc.)
- 🔐 Context injection support (ToolRuntime, MCP Context)
- 📊 Full support for MCP progress notifications and logging
- 🏷️ Namespace prefixes and naming conflict handling

## Quick Example

```python
from langchain_core.tools import tool
from fastmcp import FastMCP
from lc2mcp import register_tools

@tool
def get_weather(city: str) -> str:
    """Get current weather for a city."""
    return f"Sunny, 25°C in {city}"

mcp = FastMCP("weather-server")
register_tools(mcp, [get_weather])  # That's it!
```

## Why it fits here

This library complements `langchain-mcp` (which provides MCP → LangChain direction) by providing the reverse direction: LangChain → MCP. Together they form a complete bridge between the two ecosystems.

Made with [Cursor](https://cursor.com)