### PR TITLE
Add mcp-chaos-rig to Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [muppet-kit/inspector](https://github.com/muppet-dev/kit) - MCP Inspector with AI-assisted debugging and testing capabilities.
 - [loopwork-ai/Companion](https://github.com/loopwork-ai/Companion) - Companion is a utility for testing and debugging your MCP servers on macOS, iOS, and visionOS.
 - [greynewell/mcpbr](https://github.com/greynewell/mcpbr) 🐍 - Benchmark runner for evaluating MCP server performance and agentic capabilities.
+- [Typewise/mcp-chaos-rig](https://github.com/Typewise/mcp-chaos-rig) 📇 - A local MCP server that breaks on demand. Test your client against auth failures, disappearing tools, flaky responses, and token expiry, all from a web UI.
 
 ### Authorization Testing
 > Resources for testing MCP servers with authentication and authorization


### PR DESCRIPTION
Adds [mcp-chaos-rig](https://github.com/Typewise/mcp-chaos-rig) to the Testing Tools section.

mcp-chaos-rig is a local MCP server built for testing MCP clients. It lets you simulate auth failures, disappearing tools, flaky responses, and token expiry from a web UI. Supports bearer, OAuth, and no-auth modes, with configurable chaos settings that take effect immediately via tool list change notifications.

Built with TypeScript, available on npm as `mcp-chaos-rig`.