### PR TITLE
Add mcpproxy-go to Proxies and Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Public test endpoints:
 - [hamidra/yamcp](https://github.com/hamidra/yamcp) 📇 - An MCP workspace manager to bundle and manage MCP servers in dedicated local workspaces (e.g., for coding, design, research).
 - [lightconetech/mcp-gateway](https://github.com/lightconetech/mcp-gateway) 📇 - A gateway demo for MCP SSE Server
 - [mcpjungle/MCPJungle](https://github.com/mcpjungle/MCPJungle) 🌳 - Self-hosted MCP Registry and Proxy for ai agents
+- [mcpproxy-go](https://github.com/smart-mcp-proxy/mcpproxy-go) 🏎️ - Production-ready MCP proxy with BM25 tool filtering, quarantine security, activity logging, and web UI for routing multiple MCP servers through a single endpoint.
 - [multi-mcp](https://github.com/kfirtoledo/multi-mcp) 🐍 - A flexible and dynamic Multi-MCP Proxy Server that acts as a single MCP server while connecting to and routing between multiple backend MCP servers over STDIO or SSE. Deployable on Kubernetes by exposing a single port, and supports dynamic addition and removal of MCP servers at runtime.
 - [punkpeye/mcp-proxy](https://github.com/punkpeye/mcp-proxy) 📇 - A TypeScript SSE proxy for MCP servers that use `stdio` transport
 - [SecretiveShell/MCP-Bridge](https://github.com/SecretiveShell/MCP-Bridge) 🐍 – An openAI middleware proxy to use MCP in any existing openAI compatible client


### PR DESCRIPTION
Adding mcpproxy-go - a production-ready MCP proxy with BM25 tool filtering, quarantine security, activity logging, and web UI.