### PR TITLE
Add mcp-otel-go to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Public test endpoints:
 - [JoshuaSiraj/mcp_auto_register](https://github.com/JoshuaSiraj/mcp_auto_register) 🐍 – Tool to automate the registration of functions and classes from a Python package into a FastMCP instance
 - [isaacwasserman/mcp-langchain-ts-client](https://github.com/isaacwasserman/mcp-langchain-ts-client) 📇 – Use MCP provided tools in LangChain.js
 - [traceloop/openllmetry#opentelemetry-instrumentation-mcp](https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-mcp) 🐍 - OpenTelemetry instrumentation for MCP Python that captures tool calls, notifications, listing, initialization handshakes and propagates traces from client to server.
+- [olgasafonova/mcp-otel-go](https://github.com/olgasafonova/mcp-otel-go) 🏎️ - OpenTelemetry instrumentation for Go MCP servers using the official go-sdk. One middleware call adds tracing and metrics for every method, following the OTel semantic conventions for MCP.
 
 ## Utilities
 


### PR DESCRIPTION
## Summary

- Adds [mcp-otel-go](https://github.com/olgasafonova/mcp-otel-go) to the **Libraries** section
- OpenTelemetry tracing and metrics middleware for Go MCP servers using the official [go-sdk](https://github.com/modelcontextprotocol/go-sdk)
- Follows the [OTel semantic conventions for MCP](https://opentelemetry.io/docs/specs/semconv/gen-ai/mcp/)
- Companion to the existing Python entry (traceloop/openllmetry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)