### PR TITLE
Add Pipelock to Proxies and Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Public test endpoints:
 - [fangyinc/mcpport](https://github.com/fangyinc/mcpport) 🐍 - A lightweight gateway & registry for MCP servers with NAT traversal support, allowing edge devices to provide MCP services across networks. Features include WebSocket/SSE/HTTP endpoints, authentication, IPv6 support, and a CLI tool for easy registration of stdio-based MCP servers.
 - [hamidra/yamcp](https://github.com/hamidra/yamcp) 📇 - An MCP workspace manager to bundle and manage MCP servers in dedicated local workspaces (e.g., for coding, design, research).
 - [lightconetech/mcp-gateway](https://github.com/lightconetech/mcp-gateway) 📇 - A gateway demo for MCP SSE Server
+- [luckyPipewrench/pipelock](https://github.com/luckyPipewrench/pipelock) 🏎️ - A firewall for AI agents that wraps MCP servers with bidirectional scanning for credential leaks, prompt injection, and tool poisoning. Single Go binary.
 - [mcpjungle/MCPJungle](https://github.com/mcpjungle/MCPJungle) 🌳 - Self-hosted MCP Registry and Proxy for ai agents
 - [multi-mcp](https://github.com/kfirtoledo/multi-mcp) 🐍 - A flexible and dynamic Multi-MCP Proxy Server that acts as a single MCP server while connecting to and routing between multiple backend MCP servers over STDIO or SSE. Deployable on Kubernetes by exposing a single port, and supports dynamic addition and removal of MCP servers at runtime.
 - [punkpeye/mcp-proxy](https://github.com/punkpeye/mcp-proxy) 📇 - A TypeScript SSE proxy for MCP servers that use `stdio` transport


### PR DESCRIPTION
Adds [Pipelock](https://github.com/luckyPipewrench/pipelock) to the Utilities > Proxies and Gateways section.

Pipelock is a firewall for AI agents — it wraps MCP servers with bidirectional scanning for credential leaks, prompt injection, and tool poisoning. Ships as a single Go binary with zero runtime dependencies.

- Inserted in alphabetical order
- Uses the Go (🏎️) language icon
- Follows existing format