### PR TITLE
Add CodeMode to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Public test endpoints:
 
 > Reusable code libraries and components for MCP servers
 
+- [cnap-tech/codemode](https://github.com/cnap-tech/codemode) 📇 - Programmatic tool calling (Code Mode) for MCP — turn any OpenAPI spec into two sandboxed tools (search + execute) instead of hundreds of hand-written tools
 - [marimo-team/codemirror-mcp](https://github.com/marimo-team/codemirror-mcp) 📇 - CodeMirror extension that implements MCP for resource mentions and prompt commands
 - [jhgaylor/express-mcp-handlder](https://github.com/jhgaylor/express-mcp-handler) 📇 - Bind an MCP server to an express server using the StreamableHTTP Transport
 - [JoshuaSiraj/mcp_auto_register](https://github.com/JoshuaSiraj/mcp_auto_register) 🐍 – Tool to automate the registration of functions and classes from a Python package into a FastMCP instance


### PR DESCRIPTION
Adds [CodeMode](https://github.com/cnap-tech/codemode) to the Libraries section.

## Why

Cloudflare's [Code Mode: the better way to use MCP](https://blog.cloudflare.com/code-mode/) blog post and Anthropic's [Programmatic tool calling](https://platform.claude.com/docs/en/agents-and-tools/tool-use/programmatic-tool-calling) docs both describe **programmatic tool calling (Code Mode)** as the recommended pattern for giving LLMs API access — two tools (search the spec + execute code) instead of one tool per endpoint. This library implements that pattern as a drop-in for any MCP server.

## What it does

Turn any OpenAPI spec into two sandboxed MCP tools (`search` + `execute`) instead of hundreds of hand-written tools.

- 📇 TypeScript, MIT licensed
- Published on npm as `@robinbraemer/codemode`
- Uses isolated-vm V8 sandboxes for secure code execution
- Works with any fetch-compatible handler (Hono, Express, standard fetch)