### PR TITLE
Add cadre-ai to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 
 - [hasmcp/hasmcp-ce](https://github.com/hasmcp/hasmcp-ce) 🤖📇🏎️ - Convert your API to MCP server with built-in authentication, authorization, real-time request/response logs and metrics. HasMCP is a no-code, self-hosted API to MCP server bridge.
 - [lastmile-ai/mcp-agent](https://github.com/lastmile-ai/mcp-agent) 🤖 🔌 - Build effective agents with MCP servers using simple, composable patterns
+- [WeberG619/cadre-ai](https://github.com/WeberG619/cadre-ai) 🐍 - Your AI agent squad for Claude Code. 17 specialized agents with persistent memory, desktop automation, MCP server integration, and a common sense engine that learns from corrections.
 - [mcpdotdirect/template-mcp-server](https://github.com/mcpdotdirect/template-mcp-server) 📇 - A CLI tool to create a new MCP server project with TypeScript support
 - [p-funk/FEGIS](https://github.com/p-funk/FEGIS) 🐍 - A semantic programming framework for LLMs that compiles YAML archetypes into structured tools with built-in memory and meaning. Each interaction becomes part of an emergent knowledge graph, enabling persistent, semantic retrieval and reuse.
 - [sebastianbuzdugan/framework-rai-mcp](https://github.com/sebastianbuzdugan/framework-rai-mcp) 📇 - A responsible AI MCP server framework focused on ethical deployment in startups and enterprise prototypes.


### PR DESCRIPTION
Adds [cadre-ai](https://github.com/WeberG619/cadre-ai) to the Frameworks section.

**What it is:** A Python-based multi-agent framework for Claude Code with 17 specialized agents, persistent memory, desktop automation via MCP, and a common sense engine that learns from corrections.

**Why Frameworks:** cadre-ai is a high-level framework that orchestrates MCP servers (Windows browser, Excel, Bluebeam, voice, financial data, etc.) through specialized sub-agents. Each agent type has access to different MCP tool sets.

**Note:** Previously submitted to awesome-mcp-servers (#2095), redirected here per @punkpeye's feedback.