### PR TITLE
Add HendryAvila/Hoofy — Spec-Driven Development MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Public test endpoints:
 - [strowk/mcptee](https://github.com/strowk/mcptee/) 🏎️ - Tool to proxy MCP and log inputs and outputs to YAML file
 - [StacklokLabs/toolhive](https://github.com/Stacklok/toolhive) 🏎️ - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization
 - [addozhang/spring-rest-to-mcp](https://github.com/addozhang/spring-rest-to-mcp) 🏎️ - An [OpenRewrite](https://docs.openrewrite.org/) recipe collection that automatically converts Spring Web REST APIs to Spring AI Model Context Protocol (MCP) server tools.
+- [HendryAvila/Hoofy](https://github.com/HendryAvila/Hoofy) 🏎️ - Spec-driven development companion with persistent memory (SQLite + FTS5 + knowledge graph), adaptive change pipeline (12 flow variants), and greenfield project pipeline with Clarity Gate. 32 MCP tools. Single binary, zero dependencies.
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
 
 ## Hosting


### PR DESCRIPTION
## What

Adding [HendryAvila/Hoofy](https://github.com/HendryAvila/Hoofy) to the **Development Tools** section.

Hoofy is a spec-driven development companion MCP server written in Go that provides persistent memory (SQLite + FTS5 + knowledge graph), an adaptive change pipeline (12 flow variants), a greenfield project pipeline with Clarity Gate, and business rules extraction. 32 MCP tools. Single binary, zero dependencies. MIT License.