### PR TITLE
Add mcp-harness to Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [wong2/mcp-cli](https://github.com/wong2/mcp-cli) 🤖 - Command line inspector for manual testing
 - [muppet-kit/inspector](https://github.com/muppet-dev/kit) - MCP Inspector with AI-assisted debugging and testing capabilities.
 - [loopwork-ai/Companion](https://github.com/loopwork-ai/Companion) - Companion is a utility for testing and debugging your MCP servers on macOS, iOS, and visionOS.
+- [gabry-ts/mcp-harness](https://github.com/gabry-ts/mcp-harness) 📇 - In-memory test harness for MCP servers — supertest for MCP. Supports in-memory and subprocess modes.
 - [greynewell/mcpbr](https://github.com/greynewell/mcpbr) 🐍 - Benchmark runner for evaluating MCP server performance and agentic capabilities.
 
 ### Authorization Testing


### PR DESCRIPTION
Adds [mcp-harness](https://github.com/gabry-ts/mcp-harness) to the Testing Tools section.

**mcp-harness** is an in-memory test harness for MCP servers in TypeScript — think supertest for MCP.

- Connects directly to `McpServer` instances via `InMemoryTransport` (no child processes, no IO)
- Also supports subprocess/stdio mode for integration testing
- Framework-agnostic assertion helpers (`mcp-harness/assertions`)
- Works with Vitest, Jest, node:assert, or any test runner
- Published on npm: [`mcp-harness`](https://www.npmjs.com/package/mcp-harness)