### PR TITLE
Add MCPulse to Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [wong2/mcp-cli](https://github.com/wong2/mcp-cli) 🤖 - Command line inspector for manual testing
 - [muppet-kit/inspector](https://github.com/muppet-dev/kit) - MCP Inspector with AI-assisted debugging and testing capabilities.
 - [loopwork-ai/Companion](https://github.com/loopwork-ai/Companion) - Companion is a utility for testing and debugging your MCP servers on macOS, iOS, and visionOS.
-- [MCPulse](https://github.com/AndreyVMarkelov/MCPulse) ☕ - Apache JMeter load testing plugin for MCP servers. Supports stdio, HTTP, and HTTP+SSE transports.
+- [MCPLoadTester](https://github.com/AndreyVMarkelov/MCPLoadTester) — JMeter sampler for load testing Model Context Protocol (MCP) servers over stdio, HTTP, and SSE.
 - [garagon/aguara](https://github.com/garagon/aguara) 🏎️ - Static security scanner for MCP servers and AI agent skills. 173 detection rules, prompt injection, credential leaks, taint tracking. Scans configs and tool descriptions before deployment.
 - [greynewell/mcpbr](https://github.com/greynewell/mcpbr) 🐍 - Benchmark runner for evaluating MCP server performance and agentic capabilities.
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [wong2/mcp-cli](https://github.com/wong2/mcp-cli) 🤖 - Command line inspector for manual testing
 - [muppet-kit/inspector](https://github.com/muppet-dev/kit) - MCP Inspector with AI-assisted debugging and testing capabilities.
 - [loopwork-ai/Companion](https://github.com/loopwork-ai/Companion) - Companion is a utility for testing and debugging your MCP servers on macOS, iOS, and visionOS.
-- [MCPulse](https://github.com/AndreyVMarkelov/MCPulse) ☕ - Apache JMeter load testing plugin for MCP stdio servers. Supports initialize, tools/list, tools/call, and resources/list.
+- [MCPulse](https://github.com/AndreyVMarkelov/MCPulse) ☕ - Apache JMeter load testing plugin for MCP servers. Supports stdio, HTTP, and HTTP+SSE transports.
 - [garagon/aguara](https://github.com/garagon/aguara) 🏎️ - Static security scanner for MCP servers and AI agent skills. 173 detection rules, prompt injection, credential leaks, taint tracking. Scans configs and tool descriptions before deployment.
 - [greynewell/mcpbr](https://github.com/greynewell/mcpbr) 🐍 - Benchmark runner for evaluating MCP server performance and agentic capabilities.
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [wong2/mcp-cli](https://github.com/wong2/mcp-cli) 🤖 - Command line inspector for manual testing
 - [muppet-kit/inspector](https://github.com/muppet-dev/kit) - MCP Inspector with AI-assisted debugging and testing capabilities.
 - [loopwork-ai/Companion](https://github.com/loopwork-ai/Companion) - Companion is a utility for testing and debugging your MCP servers on macOS, iOS, and visionOS.
+- [MCPulse](https://github.com/AndreyVMarkelov/MCPulse) ☕ - Apache JMeter load testing plugin for MCP stdio servers. Supports initialize, tools/list, tools/call, and resources/list.
 - [greynewell/mcpbr](https://github.com/greynewell/mcpbr) 🐍 - Benchmark runner for evaluating MCP server performance and agentic capabilities.
 
 ### Authorization Testing


### PR DESCRIPTION
MCPLoadTester — JMeter sampler for load testing Model Context Protocol (MCP) servers over stdio, HTTP, and SSE transports. MCPLoadTester focuses on JMeter-based load testing with configurable thread groups, HTML reports, and Docker support.

GitHub: https://github.com/AndreyVMarkelov/MCPLoadTester
Language: Java ☕