### PR TITLE
Add Autohand Code CLI to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Public test endpoints:
 - [strowk/mcptee](https://github.com/strowk/mcptee/) 🏎️ - Tool to proxy MCP and log inputs and outputs to YAML file
 - [StacklokLabs/toolhive](https://github.com/Stacklok/toolhive) 🏎️ - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization
 - [addozhang/spring-rest-to-mcp](https://github.com/addozhang/spring-rest-to-mcp) 🏎️ - An [OpenRewrite](https://docs.openrewrite.org/) recipe collection that automatically converts Spring Web REST APIs to Spring AI Model Context Protocol (MCP) server tools.
+- [autohandai/code-cli](https://github.com/autohandai/code-cli) 📇 - Autonomous terminal coding agent with built-in MCP integration for external tool connectivity, 40+ native tools, and multi-provider LLM support
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
 
 ## Hosting


### PR DESCRIPTION
Hi, I think Autohand Code CLI fits well in the Development Tools section since it natively integrates with MCP for external tool connectivity.

It's a terminal-based autonomous coding agent (TypeScript) that uses MCP to extend its capabilities beyond the 40+ built-in tools. Developers can connect any MCP server to expand what the agent can do — file systems, databases, APIs, etc.

Other highlights:
- ReAct reasoning loop for multi-step coding tasks
- Works with OpenRouter, Anthropic, OpenAI, and Ollama
- VS Code and Zed editor integration
- Apache 2.0 licensed

Added it to the Development Tools subsection in alphabetical order.