### PR TITLE
Add Remote MCP Adapter devtool

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Public test endpoints:
 - [SecretiveShell/MCP-Bridge](https://github.com/SecretiveShell/MCP-Bridge) 🐍 – An openAI middleware proxy to use MCP in any existing openAI compatible client
 - [sparfenyuk/mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) 🐍 – An MCP stdio to SSE transport gateway
 - [TBXark/mcp-proxy](https://github.com/TBXark/mcp-proxy) 🏎️ - An MCP proxy server that aggregates multiple MCP resource servers through a single HTTP server
+- [aakashh242/remote-mcp-adapter](https://github.com/aakashh242/remote-mcp-adapter) 🐍 - An MCP gateway that fixes the "remote filesystem" problem: client sent files become staged uploads, server generated files become fetchable MCP resources.
 
 ### Development Tools
 


### PR DESCRIPTION
I would request to submit the [remote-mcp-adapter](https://github.com/aakashh242/remote-mcp-adapter) as a Developer Tool for the MCP Ecosystem.

It is a MCP gateway but with special handling for tools that work with files - either consume or create them. I built it to solve the issue with hosting MCP servers remotely where different filesystems cause the client and the server to be unable to exchange files.

It also implements and provides configurations for a vast array of constructs such as persisted sessions, automated cleanups, quotas etc. to cater to a wide range of deployment scenarios.
