### PR TITLE
Add Aguara to Testing Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [wong2/mcp-cli](https://github.com/wong2/mcp-cli) 🤖 - Command line inspector for manual testing
 - [muppet-kit/inspector](https://github.com/muppet-dev/kit) - MCP Inspector with AI-assisted debugging and testing capabilities.
 - [loopwork-ai/Companion](https://github.com/loopwork-ai/Companion) - Companion is a utility for testing and debugging your MCP servers on macOS, iOS, and visionOS.
+- [garagon/aguara](https://github.com/garagon/aguara) 🏎️ - Static security scanner for MCP servers and AI agent skills. 173 detection rules, prompt injection, credential leaks, taint tracking. Scans configs and tool descriptions before deployment.
 - [greynewell/mcpbr](https://github.com/greynewell/mcpbr) 🐍 - Benchmark runner for evaluating MCP server performance and agentic capabilities.
 
 ### Authorization Testing


### PR DESCRIPTION
Adds [Aguara](https://github.com/garagon/aguara) to the Testing Tools section.

Aguara is a static security scanner for MCP servers and AI agent skills. It scans tool descriptions, skill files, and MCP configurations for prompt injection, credential leaks, data exfiltration, and supply-chain attacks before deployment.

- 173 built-in detection rules across 13 categories
- 4 analysis layers: pattern matching, NLP, taint tracking, rug-pull detection
- CLI tool with SARIF output, GitHub Action, Docker image
- Go, Apache 2.0 license