### PR TITLE
Add Kryfto - 42-tool MCP server for web browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [Upsonic/gpt-computer-assistant](https://github.com/Upsonic/gpt-computer-assistant) 🐍 – Framework to build vertical AI agent
 - [microsoft/semantic-kernel](https://github.com/microsoft/semantic-kernel) 🐍 #️⃣ – Enterprise-ready orchestration framework MCP compatible from Microsoft to build intelligent AI agents and multi-agent systems.
 - [xmcp](https://github.com/basementstudio/xmcp) 📇 - A TypeScript framework with file-system routing & complete toolkit
+- [Kryfto](https://github.com/ExceptionRegret/Kryfto) 📇 - Open-source web-browsing backend for AI agents with a 42-tool MCP server for Claude Code/Cursor/Codex, REST API for n8n/Zapier/Make, federated multi-engine search, and enterprise infrastructure
 
 ## Testing Tools 
 > Tools for testing MCP servers and clients 


### PR DESCRIPTION
## Add Kryfto to Frameworks section

[Kryfto](https://github.com/ExceptionRegret/Kryfto) is an open-source web-browsing backend for AI agents & workflow engines.

### Key Features
- **42-tool MCP server** for Claude Code, Cursor, and Codex
- **Full REST API** for n8n, Zapier, and Make
- **Federated multi-engine search** across multiple providers
- **Anti-bot stealth** for reliable web access
- **Enterprise infrastructure**: Postgres, Redis, BullMQ, MinIO
- **Self-hostable** for $5/mo flat

### Details
- **Language**: TypeScript
- **License**: Open Source
- **Repository**: https://github.com/ExceptionRegret/Kryfto