### PR TITLE
Add mcp-craft — CLI toolkit for MCP server development

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 
 - [hasmcp/hasmcp-ce](https://github.com/hasmcp/hasmcp-ce) 🤖📇🏎️ - Convert your API to MCP server with built-in authentication, authorization, real-time request/response logs and metrics. HasMCP is a no-code, self-hosted API to MCP server bridge.
 - [lastmile-ai/mcp-agent](https://github.com/lastmile-ai/mcp-agent) 🤖 🔌 - Build effective agents with MCP servers using simple, composable patterns
+- [jcasare/mcp-craft](https://github.com/jcasare/mcp-craft) 📇 - CLI toolkit for scaffolding, testing, and registering MCP servers across Claude, Cursor, VS Code, Codex, and Gemini
 - [mcpdotdirect/template-mcp-server](https://github.com/mcpdotdirect/template-mcp-server) 📇 - A CLI tool to create a new MCP server project with TypeScript support
 - [p-funk/FEGIS](https://github.com/p-funk/FEGIS) 🐍 - A semantic programming framework for LLMs that compiles YAML archetypes into structured tools with built-in memory and meaning. Each interaction becomes part of an emergent knowledge graph, enabling persistent, semantic retrieval and reuse.
 - [sebastianbuzdugan/framework-rai-mcp](https://github.com/sebastianbuzdugan/framework-rai-mcp) 📇 - A responsible AI MCP server framework focused on ethical deployment in startups and enterprise prototypes.


### PR DESCRIPTION
## What is mcp-craft?

[mcp-craft](https://github.com/jcasare/mcp-craft) is a CLI toolkit for scaffolding, testing, and managing MCP servers.

### Features

- `mcp-craft init` — Interactive project scaffolding (stdio/HTTP, tools/resources/prompts)
- `mcp-craft add tool|resource|prompt` — Add capabilities to existing servers
- `mcp-craft test` — Validate servers via JSON-RPC (build, connect, list primitives)
- `mcp-craft inspect` — Launch MCP Inspector
- `mcp-craft register` — Register with 7 AI clients (Claude Desktop, Claude Code, Cursor, Windsurf, VS Code, Codex, Gemini CLI)

### Links

- npm: https://www.npmjs.com/package/mcp-craft
- GitHub: https://github.com/jcasare/mcp-craft