### PR TITLE
Add mcp2cli - CLI bridge for MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Public test endpoints:
 - [f/MCPTools](https://github.com/f/mcptools) 🏎️ - A command-line development tool for inspecting and interacting with MCP servers
 - [flux159/mcp-chat](https://github.com/flux159/mcp-chat) 📇 - A CLI based client to chat and connect with any MCP server
 - [mark3labs/mcphost](https://github.com/mark3labs/mcphost) 🏎️ - A CLI host application that enables LLMs to interact with external tools through MCP
+- [rodaddy/mcp2cli](https://github.com/rodaddy/mcp2cli) 📇 - CLI bridge that wraps MCP servers as bash-invokable commands, recovering ~11K tokens of context window per session
 - [strowk/mcp-autotest](https://github.com/strowk/mcp-autotest) 🏎️ - A command-line tool for running YAML based language-agnostic autotests
 - [strowk/synf](https://github.com/strowk/synf) 🦀 - Tool to hot-reload MCP server on changes to saved files
 - [strowk/mcptee](https://github.com/strowk/mcptee/) 🏎️ - Tool to proxy MCP and log inputs and outputs to YAML file


### PR DESCRIPTION
## New Tool

**mcp2cli** - CLI bridge that wraps MCP servers as bash-invokable commands, recovering ~11K tokens of context window per session by replacing pre-loaded MCP tool definitions with on-demand CLI calls.

Features: schema caching, batch mode, dry-run previews, auto-generated skill files.

https://github.com/rodaddy/mcp2cli