### PR TITLE
Add WritBase — MCP-native task management for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Public test endpoints:
 - [StacklokLabs/toolhive](https://github.com/Stacklok/toolhive) 🏎️ - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization
 - [addozhang/spring-rest-to-mcp](https://github.com/addozhang/spring-rest-to-mcp) 🏎️ - An [OpenRewrite](https://docs.openrewrite.org/) recipe collection that automatically converts Spring Web REST APIs to Spring AI Model Context Protocol (MCP) server tools.
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
+- [Writbase/writbase](https://github.com/Writbase/writbase) 📇 - MCP-native task management system for AI agent fleets with multi-agent permissions and inter-agent delegation.
 
 ## Hosting
 


### PR DESCRIPTION
Adds [Writbase/writbase](https://github.com/Writbase/writbase) to the Development Tools section under Utilities.

WritBase is an MCP-native task management control plane for AI agent fleets with multi-agent permissions, delegation safety, and full provenance tracking.

- Open source (Apache 2.0)
- TypeScript / MCP SDK
- Built on Supabase (Postgres)