### PR TITLE
Add onUI - UI Annotation MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Public test endpoints:
 - [strowk/mcp-autotest](https://github.com/strowk/mcp-autotest) 🏎️ - A command-line tool for running YAML based language-agnostic autotests
 - [strowk/synf](https://github.com/strowk/synf) 🦀 - Tool to hot-reload MCP server on changes to saved files
 - [strowk/mcptee](https://github.com/strowk/mcptee/) 🏎️ - Tool to proxy MCP and log inputs and outputs to YAML file
+- [onUI](https://github.com/onllm-dev/onUI) 📇 - Browser extension and MCP server for annotation-first UI pair programming with AI agents. Annotate, draw, and capture UI context from any webpage. 8 MCP tools. Claude Code, Cursor, Windsurf compatible.
 - [StacklokLabs/toolhive](https://github.com/Stacklok/toolhive) 🏎️ - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization
 - [addozhang/spring-rest-to-mcp](https://github.com/addozhang/spring-rest-to-mcp) 🏎️ - An [OpenRewrite](https://docs.openrewrite.org/) recipe collection that automatically converts Spring Web REST APIs to Spring AI Model Context Protocol (MCP) server tools.
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.


### PR DESCRIPTION
## Summary
- Adds [onUI](https://github.com/onllm-dev/onUI) to the Development Tools section
- onUI is a browser extension and MCP server for annotation-first UI pair programming with AI agents
- Supports annotating, drawing, and capturing UI context from any webpage with 8 MCP tools
- Compatible with Claude Code, Cursor, and Windsurf