### PR TITLE
Add MCP Observatory to Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [garagon/aguara](https://github.com/garagon/aguara) 🏎️ - Static security scanner for MCP servers and AI agent skills. 173 detection rules, prompt injection, credential leaks, taint tracking. Scans configs and tool descriptions before deployment.
 - [greynewell/mcpbr](https://github.com/greynewell/mcpbr) 🐍 - Benchmark runner for evaluating MCP server performance and agentic capabilities.
 - [realwigu/mcp-doctor](https://github.com/realwigu/mcp-doctor) 📇 - Zero-config CLI that auto-discovers MCP configs across Claude Code, Cursor, VS Code, Windsurf, and Claude Desktop. Tests connections via JSON-RPC handshake, audits for security issues, and benchmarks latency.
+- [KryptosAI/mcp-observatory](https://github.com/KryptosAI/mcp-observatory) 📇 - CLI + MCP server for testing MCP servers. Health scoring (0-100), schema quality audits, protocol conformance checks, JUnit/SARIF CI output, and badge generation. Works as both a CLI tool and an MCP server that AI agents can use to test other servers.
 
 ### Authorization Testing
 > Resources for testing MCP servers with authentication and authorization


### PR DESCRIPTION
Hey, I built [MCP Observatory](https://github.com/KryptosAI/mcp-observatory) — a CLI for catching capability regressions in MCP servers over time.\n\nIt snapshots what tools/prompts/resources a server exposes, saves the result as a JSON artifact, and diffs runs to flag regressions and recoveries. Also has a `scan` command that auto-discovers servers from your Claude configs.\n\nTested against 7 real servers so far (filesystem, everything, puppeteer, context7, etc). Figured it fits alongside mcpbr and mcp-doctor in the Testing Tools section.\n\nThanks for maintaining this list!