### PR TITLE
docs: add FastMCP TypeScript agent skill to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Public test endpoints:
 
 - [Model Context Protocol Specification](https://modelcontextprotocol.io/) — Official MCP specification
 - [Model Context Protocol (MCP) Quickstart](https://glama.ai/blog/2024-11-25-model-context-protocol-quickstart)
+- [fastmcp-3.0-typescript-agent_skill](https://github.com/cubaseuser123/fastmcp-3.0-typescript-agent_skill) 📇 — AI agent skill files for writing correct FastMCP TypeScript servers. Prevents hallucination of wrong APIs (official SDK, Python FastMCP) with references for tools, resources, prompts, auth, transport, and common anti-patterns.
 
 ## Tutorials
 


### PR DESCRIPTION
Adds an AI agent skill for writing correct FastMCP TypeScript (punkpeye/fastmcp) code.

Problem: AI agents frequently confuse FastMCP TS with the official MCP SDK (server.registerTool vs server.addTool) or Python FastMCP (decorators vs method calls), generating broken code.

What this provides:

1.SKILL.md entry point with core API quick-reference
2.Reference files for tools, resources, prompts, auth, and transport
3.Anti-patterns doc covering 11 common mistakes with ❌ wrong / ✅ correct examples
Compatible with Cursor, Windsurf, Roo, Claude Code, and any agent supporting skill files

Repo: https://github.com/cubaseuser123/fastmcp-3.0-typescript-agent_skill