### PR TITLE
Add mcp-anything to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Public test endpoints:
 - [StacklokLabs/toolhive](https://github.com/Stacklok/toolhive) 🏎️ - A lightweight utility designed to simplify the deployment and management of MCP servers, ensuring ease of use, consistency, and security through containerization
 - [addozhang/spring-rest-to-mcp](https://github.com/addozhang/spring-rest-to-mcp) 🏎️ - An [OpenRewrite](https://docs.openrewrite.org/) recipe collection that automatically converts Spring Web REST APIs to Spring AI Model Context Protocol (MCP) server tools.
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
+- [type-mcp/mcp-anything](https://github.com/type-mcp/mcp-anything) 🐍 - Auto-generates MCP servers from any codebase or API spec (FastAPI, Flask, Spring Boot, Express, Go, Rails, OpenAPI, GraphQL, gRPC) in one command.
 - [Writbase/writbase](https://github.com/Writbase/writbase) 📇 - MCP-native task management system for AI agent fleets with multi-agent permissions and inter-agent delegation.
 
 ## Hosting


### PR DESCRIPTION
## Summary

- Adds [type-mcp/mcp-anything](https://github.com/type-mcp/mcp-anything) to the **Development Tools** section
- mcp-anything auto-generates MCP servers from any codebase or API spec in one command
- Supports 17 detectors: FastAPI, Flask, Spring Boot, Express, Go Gin, Rails, Rust Actix, Django DRF, OpenAPI, GraphQL, gRPC, and more