### PR TITLE
Add monapi to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Public test endpoints:
 - [JoshuaSiraj/mcp_auto_register](https://github.com/JoshuaSiraj/mcp_auto_register) 🐍 – Tool to automate the registration of functions and classes from a Python package into a FastMCP instance
 - [isaacwasserman/mcp-langchain-ts-client](https://github.com/isaacwasserman/mcp-langchain-ts-client) 📇 – Use MCP provided tools in LangChain.js
 - [traceloop/openllmetry#opentelemetry-instrumentation-mcp](https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-mcp) 🐍 - OpenTelemetry instrumentation for MCP Python that captures tool calls, notifications, listing, initialization handshakes and propagates traces from client to server.
+- [DenisTheM/monapi](https://github.com/DenisTheM/monapi) 📇 - Add per-tool x402 micropayments to any MCP server. Agents pay in USDC per tool call — no API keys, no signup. Also supports Express and Next.js.
 
 ## Utilities
 


### PR DESCRIPTION
Adds [monapi](https://github.com/DenisTheM/monapi) to the Libraries section.

monapi is a TypeScript library that adds x402 micropayments to MCP server tools. Developers wrap their tool handlers with `monapiMcp()` and agents pay per call in USDC — no API keys or signup required.

- npm: [@monapi/sdk](https://www.npmjs.com/package/@monapi/sdk)
- MIT licensed, no fees
- Also supports Express and Next.js