### PR TITLE
Add Global Chat MCP server to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Public test endpoints:
 - [ithena-one/ithena-cli](https://github.com/ithena-one/ithena-cli) 🏎️ - Wraps MCP commands to log interactions locally, facilitating debugging and interaction audits. Optional cloud.
 - [f/MCPTools](https://github.com/f/mcptools) 🏎️ - A command-line development tool for inspecting and interacting with MCP servers
 - [flux159/mcp-chat](https://github.com/flux159/mcp-chat) 📇 - A CLI based client to chat and connect with any MCP server
+- [Global Chat](https://github.com/pumanitro/global-chat) 📇 - MCP server for cross-protocol AI agent discovery, searching 100K+ agents across 15+ registries (MCP, A2A, agents.txt, ACDP), with built-in agents.txt validation
 - [mark3labs/mcphost](https://github.com/mark3labs/mcphost) 🏎️ - A CLI host application that enables LLMs to interact with external tools through MCP
 - [rodaddy/mcp2cli](https://github.com/rodaddy/mcp2cli) 📇 - CLI bridge that wraps MCP servers as bash-invokable commands, recovering ~11K tokens of context window per session
 - [strowk/mcp-autotest](https://github.com/strowk/mcp-autotest) 🏎️ - A command-line tool for running YAML based language-agnostic autotests


### PR DESCRIPTION
Adds [Global Chat](https://github.com/pumanitro/global-chat) to the **Development Tools** section.

Global Chat is an MCP server for cross-protocol AI agent discovery. It lets you search 100K+ agents across 15+ registries (MCP, A2A, agents.txt, ACDP, and more) and includes a built-in agents.txt validator. Available on npm as [`@global-chat/mcp-server`](https://www.npmjs.com/package/@global-chat/mcp-server).

- TypeScript codebase (📇)
- Placed in Development Tools, alphabetically between `flux159/mcp-chat` and `mark3labs/mcphost`