### PR TITLE
Add Veridict — runtime trust scoring for MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [garagon/aguara](https://github.com/garagon/aguara) 🏎️ - Static security scanner for MCP servers and AI agent skills. 173 detection rules, prompt injection, credential leaks, taint tracking. Scans configs and tool descriptions before deployment.
 - [greynewell/mcpbr](https://github.com/greynewell/mcpbr) 🐍 - Benchmark runner for evaluating MCP server performance and agentic capabilities.
 - [realwigu/mcp-doctor](https://github.com/realwigu/mcp-doctor) 📇 - Zero-config CLI that auto-discovers MCP configs across Claude Code, Cursor, VS Code, Windsurf, and Claude Desktop. Tests connections via JSON-RPC handshake, audits for security issues, and benchmarks latency.
+- [xkumakichi/veridict](https://github.com/xkumakichi/veridict) 📇 - Runtime trust scoring middleware for MCP servers. Logs tool executions, classifies failures (timeout/error/validation), applies time-decay weighting, and produces a trust verdict (yes/caution/no).
 
 ### Authorization Testing
 > Resources for testing MCP servers with authentication and authorization


### PR DESCRIPTION
Adds [Veridict](https://github.com/xkumakichi/veridict) to the Testing Tools section.

Veridict is a TypeScript middleware that wraps MCP server tool handlers to log executions and produce runtime trust scores. It answers a question the existing tools don't cover: **"does this server actually work reliably in practice?"**

- Published on npm: `veridict@0.2.0`
- Failure classification: timeout / error / validation
- Time-decay weighting (recent 7d = 70%)
- Two-layer output: instant verdict (`yes`/`caution`/`no` + score) and detailed breakdown on demand
- MIT licensed