### PR TITLE
Add mcpkit to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 
 > High-level frameworks for working with MCP servers
 
+- [BenihDev/mcpkit](https://github.com/BenihDev/mcpkit) 📇 – Generate ready-to-use MCP servers from OpenAPI specs, databases, or YAML descriptions in a single command. TypeScript, MIT licensed. Install: `npx @fanioz/mcpkit`.
 - [cordum-io/cordum](https://github.com/cordum-io/cordum) 🏎️ – Native MCP server from a safety-first agent orchestration platform. Supports stdio + HTTP/SSE transports with 6 tools (job submission, policy evaluation, output scanning, workflow triggering, audit queries, pool status) and 7 resources.
 - [hasmcp/hasmcp-ce](https://github.com/hasmcp/hasmcp-ce) 🤖📇🏎️ - Convert your API to MCP server with built-in authentication, authorization, real-time request/response logs and metrics. HasMCP is a no-code, self-hosted API to MCP server bridge.
 - [lastmile-ai/mcp-agent](https://github.com/lastmile-ai/mcp-agent) 🤖 🔌 - Build effective agents with MCP servers using simple, composable patterns


### PR DESCRIPTION
## What

Adding [mcpkit](https://github.com/BenihDev/mcpkit) to the Frameworks section.

## Why

mcpkit generates ready-to-use MCP servers from OpenAPI specs, databases, or YAML descriptions in a single command. It's a TypeScript MCP framework/CLI that fits naturally alongside other scaffolding tools like create-mcp-ts and template-mcp-server.

## Details

- **Repo:** https://github.com/BenihDev/mcpkit
- **Language:** TypeScript 📇
- **License:** MIT
- **npm:** @fanioz/mcpkit
- **Install:** `npx @fanioz/mcpkit`