### PR TITLE
Add Not Human Search and AI Dev Jobs MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ Public test endpoints:
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
 - [type-mcp/mcp-anything](https://github.com/type-mcp/mcp-anything) 🐍 - Auto-generates MCP servers from any codebase or API spec (FastAPI, Flask, Spring Boot, Express, Go, Rails, OpenAPI, GraphQL, gRPC) in one command.
 - [Writbase/writbase](https://github.com/Writbase/writbase) 📇 - MCP-native task management system for AI agent fleets with multi-agent permissions and inter-agent delegation.
+- [AI Dev Jobs](https://aidevboard.com) 🏎️ - MCP server for searching AI developer jobs. 5,000+ positions with salary data. `npx -y @anthropic-ai/create-mcp --from https://aidevboard.com/.well-known/mcp.json`
+- [Not Human Search](https://nothumansearch.ai) 🏎️ - MCP server for discovering AI-native tools and services. Search 8,600+ sites by capability. `npx -y @anthropic-ai/create-mcp --from https://nothumansearch.ai/.well-known/mcp.json`
 
 ## Hosting
 


### PR DESCRIPTION
## Summary

Adds two MCP servers to the Development Tools section:

- **Not Human Search** — MCP server for discovering AI-native tools and services. Searches 8,600+ indexed sites by capability. Useful for developers building agents that need to find MCP servers, APIs, and AI tools programmatically.
- **AI Dev Jobs** — MCP server for searching AI developer job listings. 5,000+ positions with salary data. Useful for developer tools that surface hiring data or career resources.

Both servers support the `npx -y @anthropic-ai/create-mcp --from` installation pattern and expose `.well-known/mcp.json` manifests.

Both are Go-based hosted MCP servers with JSON-RPC endpoints.