### PR TITLE
Add SLM MCP Hub to Proxies and Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ Public test endpoints:
 - [TBXark/mcp-proxy](https://github.com/TBXark/mcp-proxy) 🏎️ - An MCP proxy server that aggregates multiple MCP resource servers through a single HTTP server
 - [aakashh242/remote-mcp-adapter](https://github.com/aakashh242/remote-mcp-adapter) 🐍 - An MCP gateway that fixes the "remote filesystem" problem: client sent files become staged uploads, server generated files become fetchable MCP resources.
 
+- [qualixar/slm-mcp-hub](https://github.com/qualixar/slm-mcp-hub) 🐍 - Universal MCP gateway that federates 430+ tools from 37 servers through one endpoint. 75% RAM reduction, background startup, auto-retry, cost tracking. `pip install slm-mcp-hub` or `npm install slm-mcp-hub`. Dual Python + Node.
+
 ### Development Tools
 
 - [koriyoshi2041/agentify](https://github.com/koriyoshi2041/agentify) 📇 - Transform any OpenAPI spec into 9 agent interface formats (MCP server, AGENTS.md, CLAUDE.md, Skills, and more) with a single command.


### PR DESCRIPTION
Adding [SLM MCP Hub](https://github.com/qualixar/slm-mcp-hub) — a universal MCP gateway that federates 430+ tools from 37 servers through a single endpoint.

- **75% RAM reduction** compared to loading all MCP servers individually
- Background startup, auto-retry (5 attempts exponential backoff), cost tracking
- Dual availability: `pip install slm-mcp-hub` or `npm install slm-mcp-hub`
- 557 tests, production-tested (Python 3.14 supported)
- Part of the [Qualixar AI Agent Reliability Platform](https://qualixar.com) — 7 OSS products, 7 arXiv papers

Thanks for maintaining this excellent curation!