### PR TITLE
Add mcp-lint (schema linter + preflight firewall) to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Public test endpoints:
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
 - [type-mcp/mcp-anything](https://github.com/type-mcp/mcp-anything) 🐍 - Auto-generates MCP servers from any codebase or API spec (FastAPI, Flask, Spring Boot, Express, Go, Rails, OpenAPI, GraphQL, gRPC) in one command.
 - [Writbase/writbase](https://github.com/Writbase/writbase) 📇 - MCP-native task management system for AI agent fleets with multi-agent permissions and inter-agent delegation.
+- [robert19001-cmyk/mcp-lint](https://github.com/robert19001-cmyk/mcp-lint) 📇 - Lints MCP tool schemas for cross-client compatibility (Claude, Cursor, Gemini, VS Code, Windsurf, Cline, OpenAI, Continue.dev). 17 rules + a runtime preflight firewall that scores risk and enforces YAML policy on agent tool calls before execution.
 
 ## Hosting
 


### PR DESCRIPTION
### What
Adds [mcp-lint](https://github.com/robert19001-cmyk/mcp-lint) to the **Development Tools** section.

### Why it's a fit
mcp-lint is a developer tool for MCP server authors — two related capabilities:

1. **Schema linter** — catches cross-client compatibility issues in MCP tool schemas (Claude, Cursor, Gemini, VS Code Copilot, Windsurf, Cline, OpenAI Agents SDK, Continue.dev). A schema that works in Claude can silently break in Cursor or OpenAI. 17 rules cover known quirks.

2. **Preflight firewall** (v0.4.0) — runtime SDK + CLI that intercepts agent tool calls before execution and returns allow/deny/require_approval/allow_with_rewrite with deterministic risk scoring and YAML policy.

```
$ mcp-lint check tools.json
$ mcp-lint preflight action.json --policy preflight.yml
```

### Stats
- 277 tests, MIT licensed, TypeScript, Node ≥20
- Published to npm as `mcp-lint`
- 7 CLI commands, subpath SDK export for embedding

### Checklist
- [x] Added to the correct section (Development Tools)
- [x] Entry follows the existing format (\`- [user/repo](url) <icon> - description\`)
- [x] Link is valid
- [x] One-line description