### PR TITLE
Add Burnish to Testing Tools — Swagger UI for MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [mclenhard/mcp-evals](https://github.com/mclenhard/mcp-evals) 🤖 - Package and Github action for running evals. 
 - [mcpjam/inspector](https://github.com/MCPJam/inspector) - Testing and debugging MCP servers.
 - [modelcontextprotocol/inspector](https://github.com/modelcontextprotocol/inspector) 📇 🎖️ - UI for testing MCP servers.
+- [danfking/burnish](https://github.com/danfking/burnish) 📇 - Swagger UI for MCP. Explorer-first client with auto-generated UI from tool outputs — cards, tables, charts, forms, pipelines. No LLM required. [Live demo](https://burnish-demo.fly.dev).
 - [wong2/mcp-cli](https://github.com/wong2/mcp-cli) 🤖 - Command line inspector for manual testing
 - [muppet-kit/inspector](https://github.com/muppet-dev/kit) - MCP Inspector with AI-assisted debugging and testing capabilities.
 - [loopwork-ai/Companion](https://github.com/loopwork-ai/Companion) - Companion is a utility for testing and debugging your MCP servers on macOS, iOS, and visionOS.


### PR DESCRIPTION
Adds [Burnish](https://github.com/danfking/burnish) to the **Testing Tools** section.

Burnish is in the same family as `modelcontextprotocol/inspector` and `mcpjam/inspector` — a UI for testing/debugging MCP servers — but takes a different shape: no LLM, no chat window. Instead, every tool's input schema becomes an auto-generated form, and every tool's JSON output renders as the right component for its shape (cards for objects, tables for arrays, charts for `{labels, datasets}`, pipelines, dashboards, etc.).

For MCP server authors, the main value is: point it at your server during development and get a live "what does my tool output actually look like to end users" view without writing any UI code or chaining through an LLM.

- **Live demo:** https://burnish-demo.fly.dev
- **Install:** \`npx burnish -- <your-mcp-server>\`
- **License:** AGPL-3.0
- **TypeScript codebase (📇)**

Slotted right after `modelcontextprotocol/inspector`. Happy to adjust placement, description, or emoji.