### PR TITLE
Add mcp-assert to Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 > Tools for testing MCP servers and clients
 
 - [AgentTrust](https://github.com/assister-xyz/quality-oracle) 🐍 - Quality verification service for MCP servers. Automated challenge-response testing with LLM judge consensus, adversarial probes, and IRT adaptive question calibration.
+- [mcp-assert](https://github.com/blackwell-systems/mcp-assert) 🏎️ - Deterministic YAML-based correctness testing for MCP servers. No LLM-as-judge. 19 assertion types, trajectory validation, snapshot regression, bidirectional MCP support, multi-transport (stdio/SSE/HTTP). GitHub Action for CI integration.
 - [mclenhard/mcp-evals](https://github.com/mclenhard/mcp-evals) 🤖 - Package and Github action for running evals. 
 - [mcpjam/inspector](https://github.com/MCPJam/inspector) - Testing and debugging MCP servers.
 - [modelcontextprotocol/inspector](https://github.com/modelcontextprotocol/inspector) 📇 🎖️ - UI for testing MCP servers.


### PR DESCRIPTION
Adds [mcp-assert](https://github.com/blackwell-systems/mcp-assert) to the Testing Tools section.

mcp-assert is a deterministic correctness testing tool for MCP servers, written in Go. It connects to any MCP server over stdio, SSE, or HTTP, calls tools, and asserts the results using YAML-defined assertions.

Key features:
- 19 assertion types + 4 trajectory types (agent tool-call sequence validation)
- Snapshot regression testing
- Bidirectional MCP support (sampling, roots, elicitation)
- Multi-transport: stdio, SSE, streamable HTTP
- GitHub Action for one-line CI integration
- No LLM-as-judge: assertions are deterministic