### PR TITLE
Add promptlint-mcp (static linter for AI prompts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Public test endpoints:
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
 - [type-mcp/mcp-anything](https://github.com/type-mcp/mcp-anything) 🐍 - Auto-generates MCP servers from any codebase or API spec (FastAPI, Flask, Spring Boot, Express, Go, Rails, OpenAPI, GraphQL, gRPC) in one command.
 - [Writbase/writbase](https://github.com/Writbase/writbase) 📇 - MCP-native task management system for AI agent fleets with multi-agent permissions and inter-agent delegation.
+- [sean-sunagaku/promptlint-mcp](https://github.com/sean-sunagaku/promptlint-mcp) 📇 - Static linter for AI prompts. Catches contradictions, redundancy, ambiguity, long examples, and politeness fluff. CLI + MCP server. Zero network, MIT.
 
 ## Hosting
 


### PR DESCRIPTION
Adds [`promptlint-mcp`](https://github.com/sean-sunagaku/promptlint-mcp), a static linter for AI prompts.

It detects contradictions, redundancy, ambiguous pronouns, oversized examples, and politeness fluff in system prompts and agent instructions. Returns a score + issue list + sentence-aware trimmed text. Zero network, zero LLM calls. CLI + MCP server. MIT.

Tools exposed:
- `lint_prompt(text)` → score, issues, trimmed text, token savings
- `trim_prompt(text)` → mechanically trimmed prompt (preserves quoted / backticked / fenced content)

Tested with Claude Code via `claude mcp add`.

Inserted at the end of the **Utilities → Development Tools** section, since promptlint-mcp is a CLI/MCP dev tool that works on prompt text rather than a proxy/SDK.