### PR TITLE
Add unslop MCP server and CLI to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Public test endpoints:
 - [addozhang/spring-rest-to-mcp](https://github.com/addozhang/spring-rest-to-mcp) 🏎️ - An [OpenRewrite](https://docs.openrewrite.org/) recipe collection that automatically converts Spring Web REST APIs to Spring AI Model Context Protocol (MCP) server tools.
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
 - [type-mcp/mcp-anything](https://github.com/type-mcp/mcp-anything) 🐍 - Auto-generates MCP servers from any codebase or API spec (FastAPI, Flask, Spring Boot, Express, Go, Rails, OpenAPI, GraphQL, gRPC) in one command.
+- [MohamedAbdallah-14/unslop](https://github.com/MohamedAbdallah-14/unslop) 📇 - CLI and MCP server that removes AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Works with Claude Code, Cursor, Codex, and Gemini CLI.
 - [Writbase/writbase](https://github.com/Writbase/writbase) 📇 - MCP-native task management system for AI agent fleets with multi-agent permissions and inter-agent delegation.
 
 ## Hosting


### PR DESCRIPTION
## Add unslop to Development Tools

**unslop** — https://github.com/MohamedAbdallah-14/unslop

A CLI and MCP server that removes AI writing patterns from text: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocabulary. Five intensity levels and a lint-only audit mode that checks without modifying.

Works with Claude Code, Cursor, Codex, and Gemini CLI via MCP. Useful during development when AI-generated docs, commit messages, or README drafts need pattern scrubbing before commit.

TypeScript implementation. Added under Development Tools in alphabetical position.
