### PR TITLE
Add KubeStellar Console kc-agent to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Public test endpoints:
 - [koriyoshi2041/agentify](https://github.com/koriyoshi2041/agentify) 📇 - Transform any OpenAPI spec into 9 agent interface formats (MCP server, AGENTS.md, CLAUDE.md, Skills, and more) with a single command.
 - [inercia/mcpshell](https://github.com/inercia/mcpshell) 🏎️ - Use shell scripts as MCP tools.
 - [ithena-one/ithena-cli](https://github.com/ithena-one/ithena-cli) 🏎️ - Wraps MCP commands to log interactions locally, facilitating debugging and interaction audits. Optional cloud.
+- [kubestellar/console kc-agent](https://github.com/kubestellar/console/tree/main/cmd/kc-agent) 🏎️ - MCP server that bridges AI agents to Kubernetes clusters, providing tools for pod management, deployments, logs, and multi-cluster operations via MCP protocol.
 - [f/MCPTools](https://github.com/f/mcptools) 🏎️ - A command-line development tool for inspecting and interacting with MCP servers
 - [flux159/mcp-chat](https://github.com/flux159/mcp-chat) 📇 - A CLI based client to chat and connect with any MCP server
 - [mark3labs/mcphost](https://github.com/mark3labs/mcphost) 🏎️ - A CLI host application that enables LLMs to interact with external tools through MCP


### PR DESCRIPTION
Adds [kc-agent](https://github.com/kubestellar/console/tree/main/cmd/kc-agent) to the **Development Tools** section.

**kc-agent** is an open-source MCP server (written in Go) that bridges AI agents to Kubernetes clusters. It provides MCP tools for pod management, deployments, logs, service discovery, and multi-cluster operations — enabling AI coding agents (Claude, Copilot, Cursor) to interact with Kubernetes directly via the MCP protocol.

Part of [KubeStellar Console](https://github.com/kubestellar/console), a CNCF Sandbox project.

- 🏎️ Go codebase
- Bridges `kubeconfig` contexts to MCP tools
- Supports multi-cluster operations
- Works with Claude Desktop, VS Code, and other MCP clients