### PR TITLE
Add caddy-mcp to Proxies and Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Public test endpoints:
 - [sparfenyuk/mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) 🐍 – An MCP stdio to SSE transport gateway
 - [TBXark/mcp-proxy](https://github.com/TBXark/mcp-proxy) 🏎️ - An MCP proxy server that aggregates multiple MCP resource servers through a single HTTP server
 - [aakashh242/remote-mcp-adapter](https://github.com/aakashh242/remote-mcp-adapter) 🐍 - An MCP gateway that fixes the "remote filesystem" problem: client sent files become staged uploads, server generated files become fetchable MCP resources.
+- * [caddy-mcp](https://github.com/venkatkrishna07/caddy-mcp) 🏎️ - Caddy plugin that exposes private MCP servers over QUIC. Dial-out from private networks (no inbound firewall ports), MCP-aware tool/resource ACLs, per-user policy intersection, structured audit logs, SSE support.
 
 ### Development Tools
 


### PR DESCRIPTION
caddy-mcp is a Caddy plugin that exposes private MCP servers via QUIC dial-out. The private host opens an outbound QUIC connection to a public Caddy instance, which then serves the MCP server as a normal HTTPS endpoint — no inbound firewall ports required.

Differentiators vs. other proxies/gateways already in the list:
- QUIC transport (TLS 1.3 from byte one, no head-of-line blocking, connection migration)
- Dial-out architecture for private/firewalled networks
- MCP-aware mode: parses JSON-RPC and enforces tool/resource ACLs before requests reach upstream
- Per-tunnel + per-user policy intersection
- Structured audit log of every tool call (token, user, tool, resource, decision, latency)

Repo: https://github.com/venkatkrishna07/caddy-mcp
License: MIT