### PR TITLE
Add olo-dot-io/Uni-CLI to Utilities > Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Public test endpoints:
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
 - [type-mcp/mcp-anything](https://github.com/type-mcp/mcp-anything) 🐍 - Auto-generates MCP servers from any codebase or API spec (FastAPI, Flask, Spring Boot, Express, Go, Rails, OpenAPI, GraphQL, gRPC) in one command.
 - [Writbase/writbase](https://github.com/Writbase/writbase) 📇 - MCP-native task management system for AI agent fleets with multi-agent permissions and inter-agent delegation.
-- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) 📇 - Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, Electron apps, and bridge CLIs through one MCP server (counts from the repo's live README STATS counters). Declarative YAML adapters with structured error envelopes (`adapter_path`, `step`, `suggestion`) let agents edit failing adapters and retry; per-call token budget published in [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md).
+- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) 📇 - Self-repairing CLI catalog that exposes web, desktop apps, Electron apps, and bridge CLIs as deterministic commands through one MCP server. Declarative YAML adapters with structured error envelopes (`adapter_path`, `step`, `suggestion`) let agents edit failing adapters and retry. Live catalog size and per-call token budget tracked in the repo's [README](https://github.com/olo-dot-io/Uni-CLI#readme) and [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md).
 
 ## Hosting
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Public test endpoints:
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
 - [type-mcp/mcp-anything](https://github.com/type-mcp/mcp-anything) 🐍 - Auto-generates MCP servers from any codebase or API spec (FastAPI, Flask, Spring Boot, Express, Go, Rails, OpenAPI, GraphQL, gRPC) in one command.
 - [Writbase/writbase](https://github.com/Writbase/writbase) 📇 - MCP-native task management system for AI agent fleets with multi-agent permissions and inter-agent delegation.
-- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) 📇 - Self-repairing CLI catalog that exposes 237+ websites, desktop apps, and external CLIs as one MCP server. 920 declarative YAML adapters; structured error envelopes (`adapter_path`, `step`, `suggestion`) let agents edit failing adapters and retry to converge on a working call. Median ~80 tokens per call.
+- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) 📇 - Self-repairing CLI catalog exposing 238 sites and 1,458 commands across web, desktop apps, Electron apps, and bridge CLIs through one MCP server (counts from the repo's live README STATS counters). Declarative YAML adapters with structured error envelopes (`adapter_path`, `step`, `suggestion`) let agents edit failing adapters and retry; per-call token budget published in [`docs/BENCHMARK.md`](https://github.com/olo-dot-io/Uni-CLI/blob/main/docs/BENCHMARK.md).
 
 ## Hosting
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Public test endpoints:
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
 - [type-mcp/mcp-anything](https://github.com/type-mcp/mcp-anything) 🐍 - Auto-generates MCP servers from any codebase or API spec (FastAPI, Flask, Spring Boot, Express, Go, Rails, OpenAPI, GraphQL, gRPC) in one command.
 - [Writbase/writbase](https://github.com/Writbase/writbase) 📇 - MCP-native task management system for AI agent fleets with multi-agent permissions and inter-agent delegation.
+- [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) 📇 - Self-repairing CLI catalog that exposes 237+ websites, desktop apps, and external CLIs as one MCP server. 920 declarative YAML adapters; structured error envelopes (`adapter_path`, `step`, `suggestion`) let agents edit failing adapters and retry to converge on a working call. Median ~80 tokens per call.
 
 ## Hosting
 


### PR DESCRIPTION
## What
Adds [olo-dot-io/Uni-CLI](https://github.com/olo-dot-io/Uni-CLI) under **Utilities → Development Tools**.

## Why this section
The section already lists CLI dev-tools that wrap or expose MCP servers (`mcp2cli`, `mcphost`, `mcp-chat`, `agentify`, `mcp-anything`, etc.). Uni-CLI is a CLI dev-tool that aggregates 237+ websites, desktop apps, and external CLIs into a single MCP server — a natural neighbor to those entries.

## What it does
Self-repairing CLI catalog. 920 declarative YAML adapters + 216 TS adapters surface 3,319 commands. Ships an optional MCP server (stdio + Streamable HTTP).

The differentiator is **self-repair**: every error is a structured envelope (`code`, `adapter_path`, `step`, `suggestion`, `retryable`, `alternatives`). When a target rotates a selector or auth, the calling agent edits the YAML at `adapter_path` and retries — no maintainer in the loop.

## Format
- Linked to repository, brief description, placed under Utilities → Development Tools.
- Icon: 📇 (TypeScript) per Legend.
- One devtool per line, appended at end of section per existing pattern.

## Project signals
- Apache-2.0, TypeScript strict, Node ≥ 20.
- npm: [`@zenalexa/unicli`](https://www.npmjs.com/package/@zenalexa/unicli).
- Latest release: v0.218.0 (2026-05-05).
- Docs: https://olo-dot-io.github.io/Uni-CLI/