### PR TITLE
Add unitedideas/agentprobe to Testing Tools 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 ## Testing Tools
 > Tools for testing MCP servers and clients
 
+- [unitedideas/agentprobe](https://github.com/unitedideas/agentprobe) 🏎️ ☁️ - Seller surface readiness tester for agentic commerce. Probes any URL and scores it 0-95 across 10 checks: llms.txt, OpenAPI, ai-plugin.json, MCP endpoint, commerce.json, catalog/quote/checkout APIs, payment rail declarations, refund/contact metadata. Grade: NOT_READY/PARTIAL/AGENT_READY/CERTIFIED. CI action + MCP tool: `probe_site(url)`.
 - [AgentTrust](https://github.com/assister-xyz/quality-oracle) 🐍 - Quality verification service for MCP servers. Automated challenge-response testing with LLM judge consensus, adversarial probes, and IRT adaptive question calibration.
 - [mclenhard/mcp-evals](https://github.com/mclenhard/mcp-evals) 🤖 - Package and Github action for running evals. 
 - [mcpjam/inspector](https://github.com/MCPJam/inspector) - Testing and debugging MCP servers.


### PR DESCRIPTION
**What**: [agentprobe](https://github.com/unitedideas/agentprobe) — seller surface readiness tester for agentic commerce.

**Why Testing Tools**: agentprobe is a testing/validation utility. Before an AI agent commits to integrating with a seller surface, it needs to know whether that surface is machine-readable enough to support autonomous transactions. agentprobe answers that question with 10 concrete checks.

**Placement**: Testing Tools section — same tier as mcp-observatory, mcp-doctor, mcpbr. agentprobe focuses on the seller surface layer rather than the MCP server itself.

**Integration surfaces**:
- CLI: `agentprobe probe <url>` 
- MCP: `probe_site(url)` → full probe report JSON
- CI: GitHub Action — fail builds when seller readiness drops below threshold

**Links**:
- Repo: https://github.com/unitedideas/agentprobe
- Live scorer: https://agentprobe.fly.dev