### PR TITLE
Add mcp-helmet to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Public test endpoints:
 - [marimo-team/codemirror-mcp](https://github.com/marimo-team/codemirror-mcp) 📇 - CodeMirror extension that implements MCP for resource mentions and prompt commands
 - [jhgaylor/express-mcp-handlder](https://github.com/jhgaylor/express-mcp-handler) 📇 - Bind an MCP server to an express server using the StreamableHTTP Transport
 - [JoshuaSiraj/mcp_auto_register](https://github.com/JoshuaSiraj/mcp_auto_register) 🐍 – Tool to automate the registration of functions and classes from a Python package into a FastMCP instance
+- [ankitvirdi4/mcp-helmet](https://github.com/ankitvirdi4/mcp-helmet) 📇 - Composable middleware for MCP servers on top of @modelcontextprotocol/sdk: bearer/API-key auth with getAuthContext() helper, rate limiter, health check, graceful shutdown, plus a CLI scaffolder with Docker template.
 - [isaacwasserman/mcp-langchain-ts-client](https://github.com/isaacwasserman/mcp-langchain-ts-client) 📇 – Use MCP provided tools in LangChain.js
 - [traceloop/openllmetry#opentelemetry-instrumentation-mcp](https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-instrumentation-mcp) 🐍 - OpenTelemetry instrumentation for MCP Python that captures tool calls, notifications, listing, initialization handshakes and propagates traces from client to server.
 - [olgasafonova/mcp-otel-go](https://github.com/olgasafonova/mcp-otel-go) 🏎️ - OpenTelemetry instrumentation for Go MCP servers using the official go-sdk. One middleware call adds tracing and metrics for every method, following the OTel semantic conventions for MCP.


### PR DESCRIPTION
## Summary

Adds [mcp-helmet](https://github.com/ankitvirdi4/mcp-helmet) under the Libraries section.

mcp-helmet is composable middleware for MCP servers built on top of `@modelcontextprotocol/sdk`. It ships:

- `bearerAuth()` and `apiKeyAuth()` middleware with an AsyncLocalStorage-based `getAuthContext()` helper, so tool handlers read the verified principal from anywhere in their async chain without changing the single-arg handler signature
- `rateLimiter()` with sliding window, IP- or key-based, standard `x-ratelimit-*` and `Retry-After` headers
- `healthCheck()` for `/healthz` and `gracefulShutdown()` for SIGTERM/SIGINT
- `npx mcp-helmet init` CLI that scaffolds a working server (TypeScript, ESM, multistage Docker image, CI-ready)

Same shape as `express-mcp-handler` and `mcp-otel-go` already in the Libraries section, so I slotted it there in alphabetical neighborhood with the other `mcp-*` entries.

Published as `mcp-helmet` on npm (v0.1.0-alpha.4). MIT.

## Test plan

- [x] Link resolves
- [x] Description matches the format and brevity of neighbouring entries
- [x] Inserted in the same Libraries section, near other `mcp-*` entries