### PR TITLE
Add FirstCall to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Public test endpoints:
 ### Development Tools
 
 - [koriyoshi2041/agentify](https://github.com/koriyoshi2041/agentify) 📇 - Transform any OpenAPI spec into 9 agent interface formats (MCP server, AGENTS.md, CLAUDE.md, Skills, and more) with a single command.
+- [FirstCall](https://github.com/rad1092/firstcall-local-api-workbench) 🦀 - Local-first verified API recipe workbench that turns request sources into redacted MCP and agent-ready API tool packages.
 - [inercia/mcpshell](https://github.com/inercia/mcpshell) 🏎️ - Use shell scripts as MCP tools.
 - [ithena-one/ithena-cli](https://github.com/ithena-one/ithena-cli) 🏎️ - Wraps MCP commands to log interactions locally, facilitating debugging and interaction audits. Optional cloud.
 - [f/MCPTools](https://github.com/f/mcptools) 🏎️ - A command-line development tool for inspecting and interacting with MCP servers


### PR DESCRIPTION
Adds FirstCall to the Development Tools section.

FirstCall is a Rust desktop + CLI workbench for turning request sources such as curl, OpenAPI, Postman, HAR, .http, Hurl, and Bruno into locally verified, redacted API recipe packages with generated MCP server artifacts.

The project was built with an AI-assisted workflow and verified with GUI/CLI lifecycle checks before release.