### PR TITLE
Add mcp-stdio-guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [mclenhard/mcp-evals](https://github.com/mclenhard/mcp-evals) 🤖 - Package and Github action for running evals. 
 - [mcpjam/inspector](https://github.com/MCPJam/inspector) - Testing and debugging MCP servers.
 - [modelcontextprotocol/inspector](https://github.com/modelcontextprotocol/inspector) 📇 🎖️ - UI for testing MCP servers.
+- [1Utkarsh1/mcp-stdio-guard](https://github.com/1Utkarsh1/mcp-stdio-guard) 📇 - Zero-dependency CLI for validating MCP stdio servers with a real initialize handshake; catches stdout pollution, invalid JSON-RPC frames, crashes, and missing responses.
 - [wong2/mcp-cli](https://github.com/wong2/mcp-cli) 🤖 - Command line inspector for manual testing
 - [muppet-kit/inspector](https://github.com/muppet-dev/kit) - MCP Inspector with AI-assisted debugging and testing capabilities.
 - [loopwork-ai/Companion](https://github.com/loopwork-ai/Companion) - Companion is a utility for testing and debugging your MCP servers on macOS, iOS, and visionOS.


### PR DESCRIPTION
Adds mcp-stdio-guard to Testing Tools.\n\nIt is a zero-dependency CLI for validating MCP stdio servers with a real initialize handshake, including stdout pollution and invalid JSON-RPC frame checks.