### PR TITLE
feat: add PHP section to SDKs (logiscape SDK + laravel-mcp-server framework)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A curated list of developer tools, SDKs, libraries, utilities, and resources for
     - [Scala](#scala)
     - [Dart](#dart)
     - [Ruby](#ruby)
+    - [PHP](#php)
     - [Elixir](#elixir)
     - [C/C++](#cc)
     - [Swift](#swift)
@@ -148,6 +149,11 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 
 - [modelcontextprotocol/ruby-sdk](https://github.com/modelcontextprotocol/ruby-sdk) 💎 🎖️ - Official Ruby SDK for building MCP servers
 - [tidewave-ai/tidewave_rails](https://github.com/tidewave-ai/tidewave_rails) 💎 - Ruby on Rails MCP, speed up development with AI assistants that understand your web application, how it runs, and what it delivers
+
+### PHP
+
+- [logiscape/mcp-sdk-php](https://github.com/logiscape/mcp-sdk-php) 🐘 - Model Context Protocol SDK for PHP. Implements stdio + HTTP transports, tool/resource/prompt registration, and JSON-RPC handling.
+- [grobinson3108/laravel-mcp-server](https://github.com/grobinson3108/laravel-mcp-server) 🐘 - Build authenticated MCP servers in Laravel 11/12/13. Bootstraps Laravel from CLI, resolves Sanctum tokens to users, and exposes a clean abstract base class for identity-scoped tools.
 
 ### Elixir
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ A curated list of developer tools, SDKs, libraries, utilities, and resources for
   * 🏎️ – Go codebase
   * 🐍 – Python codebase
   * 💎 – Ruby codebase
+  * 🐘 – PHP codebase
   * 📇 – TypeScript codebase
   * 🔶 - Kotlin codebase
   * 🦀 – Rust codebase


### PR DESCRIPTION
## What

Adds a new `### PHP` section under `## SDKs` with two entries:

- **[logiscape/mcp-sdk-php](https://github.com/logiscape/mcp-sdk-php)** — the established PHP SDK for MCP (already in production use, but currently absent from this list)
- **[grobinson3108/laravel-mcp-server](https://github.com/grobinson3108/laravel-mcp-server)** — Laravel-specific framework that wraps the above, handling Laravel boot + Sanctum token authentication + an abstract base class for identity-scoped tool callbacks

Also adds:
- 🐘 (PHP elephant) to the Legend
- A `PHP` entry to the Table of Contents (after Ruby, before Elixir)

## Why

PHP is currently the only major server-side ecosystem missing from the SDKs list. Given that ~75% of the web runs on PHP and Laravel alone has 1M+ active developers, this gap forces teams in those stacks to either re-implement their domain in TypeScript or wire `logiscape/mcp-sdk-php` manually each project — both bad outcomes for the MCP ecosystem.

Adding both entries gives PHP teams a documented entry point: start with the SDK if you want raw control, use the Laravel package if you want auth + identity scoping out of the box.

## Checklist

- [x] Entry follows existing format (`[name](url) emoji - description`)
- [x] PHP language emoji 🐘 added to Legend
- [x] TOC updated
- [x] Both repos are MIT-licensed and actively maintained
- [x] No duplicate entries

Happy to adjust phrasing or split into separate PRs if preferred.