### PR TITLE
Add Shellgate to Proxies and Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Public test endpoints:
 - [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) 🏎️ - Smart MCP proxy with BM25 tool discovery, quarantine security, Docker isolation, and web UI
 - [punkpeye/mcp-proxy](https://github.com/punkpeye/mcp-proxy) 📇 - A TypeScript SSE proxy for MCP servers that use `stdio` transport
 - [SecretiveShell/MCP-Bridge](https://github.com/SecretiveShell/MCP-Bridge) 🐍 – An openAI middleware proxy to use MCP in any existing openAI compatible client
+- [Shellgate](https://github.com/matthiastjong/shellgate) 📇 - A self-hosted security gateway that sits between AI agents and infrastructure — agents get scoped tokens, never see real credentials, and dangerous commands require human approval.
 - [sidclawhq/platform](https://github.com/sidclawhq/platform) 📇 – A governance proxy for MCP servers that adds policy-based access control, human approval workflows, and hash-chain audit trails. Wraps any upstream MCP server with zero code changes via `.mcp.json` configuration.
 - [sparfenyuk/mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) 🐍 – An MCP stdio to SSE transport gateway
 - [TBXark/mcp-proxy](https://github.com/TBXark/mcp-proxy) 🏎️ - An MCP proxy server that aggregates multiple MCP resource servers through a single HTTP server


### PR DESCRIPTION
Adds [Shellgate](https://github.com/matthiastjong/shellgate) to the **Proxies and Gateways** section.

Shellgate is an open-source (MIT), self-hosted security gateway and MCP server that sits between AI agents and infrastructure. Key capabilities:

- **Credential vault** — agents receive scoped tokens; real secrets are injected server-side and never exposed to the model
- **API proxy** — proxies HTTP requests with automatic credential injection
- **SSH execution** — with configurable guard rules so dangerous commands require human approval
- **Webhook handling, agent memories, org-wide skills, and a wiki** for shared organizational knowledge

TypeScript codebase. Placed alphabetically between SecretiveShell/MCP-Bridge and sidclawhq/platform.