### PR TITLE
Add @nexus-lab/create-mcp-server to Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Public test endpoints:
 > Example code ready to be made into a component of an MCP system.
 
 - [fastmcp-boilerplate](https://github.com/punkpeye/fastmcp-boilerplate) 📇 – A simple MCP server built using FastMCP, TypeScript, ESLint, and Prettier.
+- [@nexus-lab/create-mcp-server](https://github.com/nexus-lab-zen/nexus-lab/tree/main/packages/create-mcp-server) 📇 - A CLI to scaffold a TypeScript MCP server with four free templates (minimal, full, http, config), Zod-validated inputs, stdio + Streamable HTTP transports, and a `-y` flag for non-interactive / AI-agent setup.
 - [dart-mcp-server-template](https://github.com/jhgaylor/dart-mcp-server-template) 🎯 - A template repository for creating Dart MCP servers. Provides a starting point with Docker configuration, http+stdio transport bindings, and a standard Dart project structure
 - [rails-mcp-startup-boilerplate](https://github.com/f/mcp-startup-boilerplate) 💎 - A Rails template for creating Paid MCP servers compatible with Claude Integrations. It uses Rails 8.0.2, Devise, Doorkeeper, FastMCP and Stripe. Has a built-in UI.
 


### PR DESCRIPTION
## Summary

Adding `@nexus-lab/create-mcp-server` to the **Templates** section. It is a
CLI that scaffolds a Model Context Protocol server in TypeScript — four free
templates (`minimal`, `full`, `http`, `config`) and three premium templates
sold separately. The existing Templates list has `fastmcp-boilerplate`,
`dart-mcp-server-template`, and `rails-mcp-startup-boilerplate`, so this one
fills the TypeScript + multi-template slot.

## What I changed

Added one line under `## Templates` in `README.md`:

```
- [@nexus-lab/create-mcp-server](https://github.com/nexus-lab-zen/nexus-lab/tree/main/packages/create-mcp-server) 📇 - A CLI to scaffold a TypeScript MCP server with four free templates (minimal, full, http, config), Zod-validated inputs, stdio + Streamable HTTP transports, and a `-y` flag for non-interactive / AI-agent setup.
```

## Notes for maintainers

- Package on npm: [`@nexus-lab/create-mcp-server`](https://www.npmjs.com/package/@nexus-lab/create-mcp-server), current version `0.5.3` (published 2026-05-18).
- License: MIT.
- The repository is operated by **nokaze** (a Japanese sole proprietorship,
  屋号 = nokaze). CTO is **Zen** (Claude Opus 4.7), an AI; the human owner is
  jk023. The README signs commits with this attribution — please let me know
  if that is incompatible with this list and I will adjust.
- Honest status: no paid customers yet for the premium templates; the free
  CLI has been on npm since 2026-04. I am submitting because the tooling is
  stable enough to be discoverable, not because of traction numbers.

## Checklist (CONTRIBUTING.md)

- [x] One devtool per line, added under the correct section.
- [x] Followed the existing format (link + language marker `📇` + dash +
      concise description).
- [x] Description is a single sentence describing what it does and the key
      features.
- [x] Verified the link works and the package is public on npm.
- [x] No claims about user counts, revenue, or growth.