### PR TITLE
Add f4rkh4d/mcp to Development Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Public test endpoints:
 - [inercia/mcpshell](https://github.com/inercia/mcpshell) 🏎️ - Use shell scripts as MCP tools.
 - [ithena-one/ithena-cli](https://github.com/ithena-one/ithena-cli) 🏎️ - Wraps MCP commands to log interactions locally, facilitating debugging and interaction audits. Optional cloud.
 - [f/MCPTools](https://github.com/f/mcptools) 🏎️ - A command-line development tool for inspecting and interacting with MCP servers
+- [f4rkh4d/mcp](https://github.com/f4rkh4d/mcp) 🏎️ - Find, install, and manage MCP servers across all your AI clients (Claude Desktop, Claude Code, Cursor, Cline, Windsurf) from one command. BYOK key handling, backs up every config before writing. Single binary.
 - [flux159/mcp-chat](https://github.com/flux159/mcp-chat) 📇 - A CLI based client to chat and connect with any MCP server
 - [mark3labs/mcphost](https://github.com/mark3labs/mcphost) 🏎️ - A CLI host application that enables LLMs to interact with external tools through MCP
 - [rodaddy/mcp2cli](https://github.com/rodaddy/mcp2cli) 📇 - CLI bridge that wraps MCP servers as bash-invokable commands, recovering ~11K tokens of context window per session


### PR DESCRIPTION
Adds [`mcp`](https://github.com/f4rkh4d/mcp) under **Utilities → Development Tools**.

It's a small Go CLI in the same family as the existing entries (mcphost, mcp2cli, mcptools): one command to **find, install, and manage MCP servers across every AI client at once** — Claude Desktop, Claude Code, Cursor, Cline, and Windsurf — instead of hand-editing each app's JSON config.

- BYOK: prompts for required API keys, resolves from env → `~/.config/mcp/keys.env` (chmod 600) → prompt, and reuses a saved key across servers that need the same variable
- backs up every client config before it writes
- 21 servers in the built-in catalog, extensible via `~/.config/mcp/registry.json`
- single binary, no deps, never makes network calls (only edits local config)

Format follows the existing list style; placed in the Development Tools subsection alphabetically near the other CLIs. 🏎️ = Go.