### PR TITLE
Add adityachilka1/mcp-devtools (Chrome DevTools for MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ Public test endpoints:
 - [taskade/mcp](https://github.com/taskade/mcp/tree/main/packages/openapi-codegen) 📇 - Generate MCP tools from OpenAPI schemas. Supports auto-linking, response normalization, and MCP server integration.
 - [type-mcp/mcp-anything](https://github.com/type-mcp/mcp-anything) 🐍 - Auto-generates MCP servers from any codebase or API spec (FastAPI, Flask, Spring Boot, Express, Go, Rails, OpenAPI, GraphQL, gRPC) in one command.
 - [Writbase/writbase](https://github.com/Writbase/writbase) 📇 - MCP-native task management system for AI agent fleets with multi-agent permissions and inter-agent delegation.
+- [adityachilka1/mcp-devtools](https://github.com/adityachilka1/mcp-devtools) 📇 - Chrome DevTools for the Model Context Protocol — inspect, profile, replay, and diff every MCP call your agent makes via a local proxy with a browser UI. Includes record/replay to gzipped .mcptrace files and an embed API for instrumenting your own server.
+
 
 ## Hosting
 


### PR DESCRIPTION
Hi @punkpeye — adding `mcp-devtools` under Utilities → Development Tools.

**What it does**
A local-first inspector and profiler for MCP. Sits between any MCP client (Claude Desktop, Cursor, your own agent) and your server as a transparent proxy, and streams every JSON-RPC frame into a browser UI with a timeline, detail view, and schema explorer. Also ships a `record` mode that captures a session to a gzipped `.mcptrace` artifact you can replay later or attach to a bug report, and an embed API for instrumenting servers you author.

**Why it fits**
- Local-first, no telemetry, no daemon — drop in front of any stdio MCP server with one command.
- Solves the "I just `console.log` everything" problem most MCP authors run into.
- Cross-platform (macOS / Linux / Windows; Node 20 and 22), MIT, CI green across all six matrix jobs.
- v0.1.0 released yesterday with the proxy, recorder, viewer, and embed API ready.

**Links**
- Repo: https://github.com/adityachilka1/mcp-devtools
- Release: https://github.com/adityachilka1/mcp-devtools/releases/tag/v0.1.0
- Examples: https://github.com/adityachilka1/mcp-devtools-examples

Happy to adjust the wording, move sections, or split this into multiple entries (it's also a fit for Proxies and Gateways) if you'd prefer. Thanks for maintaining the list — it's been one of my first stops every time I look for new MCP tooling.
