### PR TITLE
Add bosslesss/inference-labs-mcp under Proxies and Gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Public test endpoints:
 - [MCPProxy](https://github.com/smart-mcp-proxy/mcpproxy-go) 🏎️ - Smart MCP proxy with BM25 tool discovery, quarantine security, Docker isolation, and web UI
 - [punkpeye/mcp-proxy](https://github.com/punkpeye/mcp-proxy) 📇 - A TypeScript SSE proxy for MCP servers that use `stdio` transport
 - [SecretiveShell/MCP-Bridge](https://github.com/SecretiveShell/MCP-Bridge) 🐍 – An openAI middleware proxy to use MCP in any existing openAI compatible client
+- [bosslesss/inference-labs-mcp](https://github.com/bosslesss/inference-labs-mcp) 🐍 - Vendor-neutral routing gateway for GPT-5 / Claude / Gemini / Bedrock via MCP, with auth-free pricing and model recommendation tools plus authenticated routing and model comparison tools.
 - [sidclawhq/platform](https://github.com/sidclawhq/platform) 📇 – A governance proxy for MCP servers that adds policy-based access control, human approval workflows, and hash-chain audit trails. Wraps any upstream MCP server with zero code changes via `.mcp.json` configuration.
 - [sparfenyuk/mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) 🐍 – An MCP stdio to SSE transport gateway
 - [TBXark/mcp-proxy](https://github.com/TBXark/mcp-proxy) 🏎️ - An MCP proxy server that aggregates multiple MCP resource servers through a single HTTP server


### PR DESCRIPTION
Hi! This adds [bosslesss/inference-labs-mcp](https://github.com/bosslesss/inference-labs-mcp) to **Utilities → Proxies and Gateways**.

Why this section:

- It acts as a vendor-neutral routing gateway for MCP clients.
- Supports provider selection across OpenAI/Azure, Anthropic, Google, and Bedrock.
- Exposes auth-free pricing/recommendation tools and authenticated routing/comparison tools.

Happy to move the entry if another section is preferred.