### PR TITLE
Add SkillTotal (static security scanner for AI components)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [xkumakichi/veridict](https://github.com/xkumakichi/veridict) 📇 - Runtime trust scoring middleware for MCP servers. Logs tool executions, classifies failures (timeout/error/validation), applies time-decay weighting, and produces a trust verdict (yes/caution/no).
 - [KryptosAI/mcp-observatory](https://github.com/KryptosAI/mcp-observatory) 📇 - CLI + MCP server for testing MCP servers. Health scoring (0-100), schema quality audits, protocol conformance checks, JUnit/SARIF CI output, and badge generation. Works as both a CLI tool and an MCP server that AI agents can use to test other servers.
 - [Booyaka101/mcp-vet](https://github.com/Booyaka101/mcp-vet) 📇 - Zero-config CLI and library that scans MCP server source (TypeScript/JavaScript/Python) for patterns that break under the 2026-07-28 MCP spec, with autofix, SARIF output, and CI-ready exit codes.
+- [pezhik/skilltotal](https://github.com/pezhik/skilltotal) 🐍 - Offline static security scanner for MCP servers (also agent skills/plugins and npm/PyPI packages). Deterministic regex+AST detection, no LLM, no account; flags tool poisoning/shadowing, prompt-injection surfaces and exfiltration paths. JSON/SARIF output, GitHub Action and pre-commit hook.
 
 ### Authorization Testing
 > Resources for testing MCP servers with authentication and authorization


### PR DESCRIPTION
This adds [pezhik/skilltotal](https://github.com/pezhik/skilltotal) to the Testing Tools section. SkillTotal is a free, Apache-2.0, offline static security scanner for MCP servers (and agent skills/plugins, npm/PyPI packages) that uses deterministic regex + AST detection with no LLM and no account. It flags MCP tool poisoning/shadowing, prompt-injection surfaces, and exfiltration paths, and outputs JSON/SARIF with a GitHub Action and pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)