### PR TITLE
Add authgent - OAuth conformance scanner for MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 ### Authorization Testing
 > Resources for testing MCP servers with authentication and authorization
 
+- [authgent/authgent](https://github.com/authgent/authgent) 🐍 - OAuth 2.1 conformance scanner for MCP servers. `authgent-server lint <url>` grades a server A–F against the MCP authorization spec and its underlying RFCs (9728 Protected Resource Metadata, 8414, 7636 PKCE, 8707 Resource Indicators, 9207). Runs as a CLI, a GitHub Action, or a hosted scanner, and emits an embeddable badge.
 - [NapthaAI/http-oauth-mcp-server](https://github.com/NapthaAI/http-oauth-mcp-server) 📇 - Example implementation of a remote MCP server with OAuth authentication
 - [modelcontextprotocol/python-sdk](https://github.com/modelcontextprotocol/python-sdk/tree/main/examples/servers/simple-auth/mcp_simple_auth) 🐍 🎖️ - Example authenticated SSE server in the official Python SDK
 


### PR DESCRIPTION
### What

Adds [authgent](https://github.com/authgent/authgent) to the **Testing Tools → Authorization Testing** subsection.

### Why it fits this list

authgent is a devtool for testing MCP servers' authorization posture — exactly what the Authorization Testing subsection is for. Unlike the existing entries (which are example servers / public test endpoints), authgent is an actual **conformance scanner**:

- `authgent-server lint <url>` grades any MCP server **A–F** against the [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) and its underlying RFCs: 9728 (Protected Resource Metadata), 8414 (AS Metadata), 7636 (PKCE), 8707 (Resource Indicators), 9207 (issuer).
- Runs three ways from one code path: **CLI**, **GitHub Action** (CI gating), and a **hosted scanner**.
- Emits an **embeddable SVG badge** so servers can advertise their grade.
- Apache-2.0, Python, actively maintained.

### Format checklist

- [x] Added under the relevant subsection (Authorization Testing)
- [x] One entry, one line, following the existing `- [name](repo) 🐍 - description` format
- [x] Language emoji included (🐍 Python codebase, per the Legend)
- [x] Link points to the GitHub repository
- [x] Concise, accurate description

Disclosure: I maintain authgent.