### PR TITLE
Add mcp-vet to Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [realwigu/mcp-doctor](https://github.com/realwigu/mcp-doctor) 📇 - Zero-config CLI that auto-discovers MCP configs across Claude Code, Cursor, VS Code, Windsurf, and Claude Desktop. Tests connections via JSON-RPC handshake, audits for security issues, and benchmarks latency.
 - [xkumakichi/veridict](https://github.com/xkumakichi/veridict) 📇 - Runtime trust scoring middleware for MCP servers. Logs tool executions, classifies failures (timeout/error/validation), applies time-decay weighting, and produces a trust verdict (yes/caution/no).
 - [KryptosAI/mcp-observatory](https://github.com/KryptosAI/mcp-observatory) 📇 - CLI + MCP server for testing MCP servers. Health scoring (0-100), schema quality audits, protocol conformance checks, JUnit/SARIF CI output, and badge generation. Works as both a CLI tool and an MCP server that AI agents can use to test other servers.
+- [Booyaka101/mcp-vet](https://github.com/Booyaka101/mcp-vet) 📇 - Zero-config CLI and library that scans MCP server source (TypeScript/JavaScript/Python) for patterns that break under the 2026-07-28 MCP spec, with autofix, SARIF output, and CI-ready exit codes.
 
 ### Authorization Testing
 > Resources for testing MCP servers with authentication and authorization


### PR DESCRIPTION
Adds [mcp-vet](https://github.com/Booyaka101/mcp-vet) under **Testing Tools**.

It's a zero-config CLI + library that statically scans MCP server source (TypeScript / JavaScript / Python) for patterns that break under the MCP `2026-07-28` spec — removed sessions and `initialize` handshake, `-32002` → `-32602`, removed `tasks/list` / `tasks/result`, and the deprecated `roots` / `sampling` / `logging` capabilities. It matches real SDK registration (schema constants, capability constructors, `sessionIdGenerator`), has an `--fix` for the mechanical rewrite, and emits SARIF/JSON with CI-ready exit codes.

- One entry, added to the bottom of the Testing Tools list, matching the existing `- [owner/repo](url) 📇 - Description.` format (📇 = TypeScript codebase).
- npm: `@booyaka/mcp-vet`, MIT.