### PR TITLE
Add modelcontextprotocol/go-sdk to Go SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [ggoodman/mcp-server-go](https://github.com/ggoodman/mcp-server-go) 🏎️ - Build MCP servers that scale from a 20‑line stdio prototype to a horizontally scaled, OIDC‑protected streaming HTTP deployment — without rewriting business logic.
 - [mark3labs/mcp-go](https://github.com/mark3labs/mcp-go) 🏎️ - Golang SDK for building MCP Servers and Clients
 - [metoro-io/mcp-golang](https://github.com/metoro-io/mcp-golang) 🏎️ - Golang framework for building MCP Servers, focussed on type safety
+- [modelcontextprotocol/go-sdk](https://github.com/modelcontextprotocol/go-sdk) 🏎️ 🎖️ - The official Go SDK for MCP servers and clients, maintained in collaboration with Google
 - [strowk/foxy-contexts](https://github.com/strowk/foxy-contexts) 🏎️ - Golang library to write MCP Servers declaratively with functional testing included
 
 ### Rust


### PR DESCRIPTION
The official Go SDK for MCP servers and clients, maintained in collaboration with Google. Noticed it was missing from the Go SDKs section.