### PR TITLE
Add AgentGate (local MCP/agent-skills security scanner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [xkumakichi/veridict](https://github.com/xkumakichi/veridict) 📇 - Runtime trust scoring middleware for MCP servers. Logs tool executions, classifies failures (timeout/error/validation), applies time-decay weighting, and produces a trust verdict (yes/caution/no).
 - [KryptosAI/mcp-observatory](https://github.com/KryptosAI/mcp-observatory) 📇 - CLI + MCP server for testing MCP servers. Health scoring (0-100), schema quality audits, protocol conformance checks, JUnit/SARIF CI output, and badge generation. Works as both a CLI tool and an MCP server that AI agents can use to test other servers.
 - [Booyaka101/mcp-vet](https://github.com/Booyaka101/mcp-vet) 📇 - Zero-config CLI and library that scans MCP server source (TypeScript/JavaScript/Python) for patterns that break under the 2026-07-28 MCP spec, with autofix, SARIF output, and CI-ready exit codes.
+- [wookat/agentgate](https://github.com/wookat/agentgate) 📇 - Scan, lock, and CI-gate MCP servers: tool-poisoning/credential scanning, a tool-surface lockfile (rug-pull defense), a drift-failing CI action with SARIF output, and a public advisory database.
 
 ### Authorization Testing
 > Resources for testing MCP servers with authentication and authorization

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ If an SDK is part of a monorepo, its popularity is counted as 0 stars.
 - [xkumakichi/veridict](https://github.com/xkumakichi/veridict) 📇 - Runtime trust scoring middleware for MCP servers. Logs tool executions, classifies failures (timeout/error/validation), applies time-decay weighting, and produces a trust verdict (yes/caution/no).
 - [KryptosAI/mcp-observatory](https://github.com/KryptosAI/mcp-observatory) 📇 - CLI + MCP server for testing MCP servers. Health scoring (0-100), schema quality audits, protocol conformance checks, JUnit/SARIF CI output, and badge generation. Works as both a CLI tool and an MCP server that AI agents can use to test other servers.
 - [Booyaka101/mcp-vet](https://github.com/Booyaka101/mcp-vet) 📇 - Zero-config CLI and library that scans MCP server source (TypeScript/JavaScript/Python) for patterns that break under the 2026-07-28 MCP spec, with autofix, SARIF output, and CI-ready exit codes.
-- [wookat/agentgate](https://github.com/wookat/agentgate) 📇 - Scan, lock, and CI-gate MCP servers: tool-poisoning/credential scanning, a tool-surface lockfile (rug-pull defense), a drift-failing CI action with SARIF output, and a public advisory database.
+- [wookat/agentgate](https://github.com/wookat/agentgate) 📇 - Static security scanner and lockfile for MCP server configs and agent skills. Detects tool poisoning and credential leaks, pins the approved tool surface in a lockfile (rug-pull defense), fails CI on drift with SARIF output, and cross-checks a public advisory database.
 
 ### Authorization Testing
 > Resources for testing MCP servers with authentication and authorization


### PR DESCRIPTION
Adds **AgentGate** — a local, zero-execution security scanner for MCP configurations, agent skills (SKILL.md), plugins/commands, and lockfile poisoning. Ships with a public advisory database (110 entries) and query API, SARIF output and CI gating.

Repo: https://github.com/wookat/agentgate
Site: https://agentgate.zalize.com